### PR TITLE
Add session layer for connection, auth, and command execution

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -13,11 +13,26 @@ jobs:
     name: Test against ponyc main
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:nightly
+    services:
+      redis:
+        image: redis:7
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4.1.1
-      - name: Test
-        run: make test config=debug
+      - name: Unit tests
+        run: make unit-tests config=debug ssl=libressl
+      - name: Integration tests
+        run: make integration-tests config=debug ssl=libressl
+        env:
+          REDIS_HOST: redis
+          REDIS_PORT: 6379
+      - name: Build examples
+        run: make build-examples config=debug ssl=libressl
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,8 +39,23 @@ jobs:
     name: Test against recent ponyc release
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:release
+    services:
+      redis:
+        image: redis:7
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4.1.1
-      - name: Test
-        run: make test config=debug
+      - name: Unit tests
+        run: make unit-tests config=debug ssl=libressl
+      - name: Integration tests
+        run: make integration-tests config=debug ssl=libressl
+        env:
+          REDIS_HOST: redis
+          REDIS_PORT: 6379
+      - name: Build examples
+        run: make build-examples config=debug ssl=libressl

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,10 +3,28 @@
 ## Building
 
 ```
-make          # build and run tests
-make test     # same as above
-make clean    # clean build artifacts
+make                    # build and run all tests (requires Redis running)
+make unit-tests         # run unit tests only (no Redis needed)
+make integration-tests  # run integration tests only (requires Redis)
+make build-examples     # build example programs
+make start-redis        # start Redis in Docker for local testing
+make stop-redis         # stop and remove Docker Redis
+make clean              # clean build artifacts
 ```
+
+All build targets require `ssl=<version>` (e.g., `ssl=3.0.x` for OpenSSL 3.x, `ssl=libressl` for LibreSSL). This is needed because lori depends on the ssl package. Add `config=debug` for debug builds.
+
+### Running Tests Locally
+
+```
+make start-redis
+make test config=debug ssl=3.0.x
+make stop-redis
+```
+
+## Dependencies
+
+- `ponylang/lori` (0.8.1) — TCP networking (transitively depends on `ponylang/ssl`, hence the `ssl=` build flag)
 
 ## Architecture
 
@@ -18,6 +36,41 @@ Package: `redis`
 - `RespMalformed` (in `resp_value.pony`): Parser error type indicating invalid RESP data. Not part of `RespValue` — represents a protocol violation, not a valid value.
 - `_RespParser` (in `_resp_parser.pony`): Two-pass parser — peek-based completeness check, then destructive parse. Returns `(RespValue | None | RespMalformed)` from a `buffered.Reader`.
 - `_RespSerializer` (in `_resp_serializer.pony`): Serializes commands (`Array[ByteSeq] val`) to RESP2 wire format.
+
+### Session Layer
+
+- `Session` (actor in `session.pony`): Main entry point. Manages connection lifecycle via a state machine. Implements `lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver`. All state machine classes (`_SessionUnopened`, `_SessionConnected`, `_SessionReady`, `_SessionClosed`) are in `session.pony`, following the postgres pattern.
+- `ConnectInfo` (in `connect_info.pony`): Connection configuration (host, port, optional password).
+- `SessionStatusNotify` (in `session_status_notify.pony`): Lifecycle callback interface. All callbacks have default no-op implementations. Callbacks: `redis_session_connected`, `redis_session_connection_failed`, `redis_session_ready`, `redis_session_authentication_failed`, `redis_session_closed`.
+- `ResultReceiver` (in `result_receiver.pony`): Command response callback interface. Callbacks: `redis_response`, `redis_command_failed`.
+- `ClientError` (in `client_error.pony`): Client-side error trait with `SessionNotReady` and `SessionClosed` primitives.
+- `_ResponseHandler` (in `_response_handler.pony`): Loops `_RespParser` over a `buffered.Reader`, delivering parsed `RespValue`s to the current state. Shuts down on `RespMalformed`.
+- `_IllegalState` / `_Unreachable` (in `_mort.pony`): Primitives for detecting impossible states.
+
+### State Machine
+
+```
+_SessionUnopened ──on_connected──► _SessionConnected (if password)
+                 ──on_connected──► _SessionReady (if no password)
+
+_SessionConnected ──AUTH OK──► _SessionReady
+                  ──AUTH error──► _SessionClosed
+
+_SessionReady ──close/error──► _SessionClosed
+```
+
+Command execution in `_SessionReady` is serialized: one command in flight at a time, with a queue for pending commands.
+
+## Test Infrastructure
+
+- Unit tests: `--exclude=integration/` — no external dependencies
+- Integration tests: `--only=integration/` — require a running Redis server
+- Test names prefixed with `integration/` for filtering
+- `_RedisTestConfiguration` reads `REDIS_HOST` and `REDIS_PORT` from environment (defaults to `127.0.0.2`/`6379` on Linux for WSL2 compatibility)
+
+### CI
+
+Both `pr.yml` and `breakage-against-ponyc-latest.yml` use the `shared-docker-ci-standard-builder-with-libressl-4.2.0` image (for ssl support) and a `redis:7` service container with health checks. Integration tests receive `REDIS_HOST=redis` and `REDIS_PORT=6379` as environment variables. All make targets pass `ssl=libressl`.
 
 ## File Layout
 

--- a/corral.json
+++ b/corral.json
@@ -11,6 +11,9 @@
     "name": "redis"
   },
   "deps": [
-    {}
+    {
+      "locator": "github.com/ponylang/lori.git",
+      "version": "0.8.1"
+    }
   ]
 }

--- a/examples/basic/main.pony
+++ b/examples/basic/main.pony
@@ -1,5 +1,53 @@
+use "cli"
+use lori = "lori"
+// in your code this `use` statement would be:
+// use "redis"
 use "../../redis"
 
 actor Main
   new create(env: Env) =>
-    env.out.print("Redis client example")
+    let info = ServerInfo(env.vars)
+    let auth = lori.TCPConnectAuth(env.root)
+    Client(auth, info, env.out)
+
+actor Client is (SessionStatusNotify & ResultReceiver)
+  let _session: Session
+  let _out: OutStream
+
+  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+    _out = out
+    _session = Session(
+      ConnectInfo(auth, info.host, info.port),
+      this)
+
+  be redis_session_ready(session: Session) =>
+    _out.print("Connected and ready.")
+    let cmd: Array[ByteSeq] val = ["SET"; "hello"; "world"]
+    session.execute(cmd, this)
+
+  be redis_session_connection_failed(session: Session) =>
+    _out.print("Failed to connect.")
+
+  be redis_response(session: Session, response: RespValue) =>
+    match response
+    | let s: RespSimpleString => _out.print("Response: " + s.value)
+    | let e: RespError => _out.print("Error: " + e.message)
+    end
+    _session.close()
+
+  be redis_command_failed(session: Session,
+    command: Array[ByteSeq] val, failure: ClientError)
+  =>
+    _out.print("Command failed: " + failure.message())
+    _session.close()
+
+class val ServerInfo
+  let host: String
+  let port: String
+
+  new val create(vars: (Array[String] val | None)) =>
+    let e = EnvVars(vars)
+    host = try e("REDIS_HOST")? else
+      ifdef linux then "127.0.0.2" else "localhost" end
+    end
+    port = try e("REDIS_PORT")? else "6379" end

--- a/redis/_mort.pony
+++ b/redis/_mort.pony
@@ -1,0 +1,33 @@
+use @exit[None](status: U8)
+use @fprintf[I32](stream: Pointer[U8] tag, fmt: Pointer[U8] tag, ...)
+use @pony_os_stderr[Pointer[U8]]()
+
+primitive _IllegalState
+  """
+  To be used to exit early if we called a function that shouldn't be possible
+  in our current state.
+  """
+  fun apply(loc: SourceLoc = __loc) =>
+    @fprintf(
+      @pony_os_stderr(),
+      ("An illegal state was encountered in %s at line %s\n" +
+       "Please open an issue at https://github.com/ponylang/redis/issues")
+       .cstring(),
+      loc.file().cstring(),
+      loc.line().string().cstring())
+    @exit(1)
+
+primitive _Unreachable
+  """
+  To be used in places that the compiler can't prove is unreachable but we are
+  certain is unreachable and if we reach it, we'd be silently hiding a bug.
+  """
+  fun apply(loc: SourceLoc = __loc) =>
+    @fprintf(
+      @pony_os_stderr(),
+      ("The unreachable was reached in %s at line %s\n" +
+       "Please open an issue at https://github.com/ponylang/redis/issues")
+       .cstring(),
+      loc.file().cstring(),
+      loc.line().string().cstring())
+    @exit(1)

--- a/redis/_response_handler.pony
+++ b/redis/_response_handler.pony
@@ -1,0 +1,25 @@
+use "buffered"
+
+primitive _ResponseHandler
+  """
+  Loops `_RespParser` over a buffered Reader, delivering each parsed
+  `RespValue` to the session's current state. Called from `on_received`
+  after new data is appended to the reader.
+
+  If parsing returns `RespMalformed`, the session is shut down — once
+  the protocol stream is corrupt, there is no way to resynchronize.
+
+  If a callback triggers shutdown, the shutdown path clears the readbuf,
+  causing the next `_RespParser` call to return `None` and exit the loop
+  naturally.
+  """
+  fun apply(s: Session ref, readbuf: Reader) =>
+    while true do
+      match _RespParser(readbuf)
+      | let v: RespValue => s.state.on_response(s, v)
+      | None => return
+      | let _: RespMalformed =>
+        s.state.shutdown(s)
+        return
+      end
+    end

--- a/redis/_test.pony
+++ b/redis/_test.pony
@@ -34,3 +34,12 @@ actor \nodoc\ Main is TestList
     test(_TestRespSerializerSingleElement)
     test(_TestRespSerializerEmptyCommand)
     test(_TestRespSerializerBinaryData)
+
+    // Session integration tests
+    test(_TestSessionConnectAndReady)
+    test(_TestSessionSetAndGet)
+    test(_TestSessionConnectionFailure)
+    test(_TestSessionExecuteBeforeReady)
+    test(_TestSessionExecuteAfterClose)
+    test(_TestSessionMultipleCommands)
+    test(_TestSessionServerError)

--- a/redis/_test_session.pony
+++ b/redis/_test_session.pony
@@ -1,0 +1,375 @@
+use "cli"
+use lori = "lori"
+use "pony_test"
+
+class \nodoc\ val _RedisTestConfiguration
+  let host: String
+  let port: String
+
+  new val create(vars: (Array[String] val | None)) =>
+    let e = EnvVars(vars)
+    host = try e("REDIS_HOST")? else
+      ifdef linux then "127.0.0.2" else "localhost" end
+    end
+    port = try e("REDIS_PORT")? else "6379" end
+
+// integration/Session/ConnectAndReady
+
+class \nodoc\ iso _TestSessionConnectAndReady is UnitTest
+  fun name(): String =>
+    "integration/Session/ConnectAndReady"
+
+  fun apply(h: TestHelper) =>
+    let info = _RedisTestConfiguration(h.env.vars)
+    let auth = lori.TCPConnectAuth(h.env.root)
+    let session = Session(
+      ConnectInfo(auth, info.host, info.port),
+      _ConnectAndReadyNotify(h))
+    h.dispose_when_done(session)
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _ConnectAndReadyNotify is SessionStatusNotify
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+
+  be redis_session_ready(session: Session) =>
+    _h.complete(true)
+
+  be redis_session_connection_failed(session: Session) =>
+    _h.fail("Connection failed")
+    _h.complete(false)
+
+// integration/Session/SetAndGet
+
+class \nodoc\ iso _TestSessionSetAndGet is UnitTest
+  fun name(): String =>
+    "integration/Session/SetAndGet"
+
+  fun apply(h: TestHelper) =>
+    let info = _RedisTestConfiguration(h.env.vars)
+    let auth = lori.TCPConnectAuth(h.env.root)
+    let client = _SetAndGetClient(h)
+    let session = Session(
+      ConnectInfo(auth, info.host, info.port),
+      client)
+    h.dispose_when_done(session)
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _SetAndGetClient is (SessionStatusNotify & ResultReceiver)
+  let _h: TestHelper
+  var _step: USize = 0
+
+  new create(h: TestHelper) =>
+    _h = h
+
+  be redis_session_ready(session: Session) =>
+    let set_cmd: Array[ByteSeq] val =
+      ["SET"; "_test_set_and_get"; "hello_redis"]
+    session.execute(set_cmd, this)
+
+  be redis_response(session: Session, response: RespValue) =>
+    _step = _step + 1
+    if _step == 1 then
+      // SET response — should be +OK
+      match response
+      | let s: RespSimpleString =>
+        if s.value != "OK" then
+          _h.fail("Expected OK from SET, got: " + s.value)
+          _h.complete(false)
+          return
+        end
+      else
+        _h.fail("Expected RespSimpleString from SET")
+        _h.complete(false)
+        return
+      end
+      let get_cmd: Array[ByteSeq] val = ["GET"; "_test_set_and_get"]
+      session.execute(get_cmd, this)
+    elseif _step == 2 then
+      // GET response — should be bulk string "hello_redis"
+      match response
+      | let b: RespBulkString =>
+        let value = String.from_array(b.value)
+        if value != "hello_redis" then
+          _h.fail("Expected 'hello_redis', got: '" + value + "'")
+          _h.complete(false)
+          return
+        end
+      else
+        _h.fail("Expected RespBulkString from GET")
+        _h.complete(false)
+        return
+      end
+      // Clean up test key
+      let del_cmd: Array[ByteSeq] val = ["DEL"; "_test_set_and_get"]
+      session.execute(del_cmd, this)
+    else
+      // DEL response — done
+      _h.complete(true)
+    end
+
+  be redis_command_failed(session: Session,
+    command: Array[ByteSeq] val, failure: ClientError)
+  =>
+    _h.fail("Command failed: " + failure.message())
+    _h.complete(false)
+
+  be redis_session_connection_failed(session: Session) =>
+    _h.fail("Connection failed")
+    _h.complete(false)
+
+// integration/Session/ConnectionFailure
+
+class \nodoc\ iso _TestSessionConnectionFailure is UnitTest
+  fun name(): String =>
+    "integration/Session/ConnectionFailure"
+
+  fun apply(h: TestHelper) =>
+    let auth = lori.TCPConnectAuth(h.env.root)
+    // Connect to a port that is (almost certainly) not listening.
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let session = Session(
+      ConnectInfo(auth, host, "59872"),
+      _ConnectionFailureNotify(h))
+    h.dispose_when_done(session)
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _ConnectionFailureNotify is SessionStatusNotify
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+
+  be redis_session_connection_failed(session: Session) =>
+    _h.complete(true)
+
+  be redis_session_ready(session: Session) =>
+    _h.fail("Should not have connected")
+    _h.complete(false)
+
+// integration/Session/ExecuteBeforeReady
+
+class \nodoc\ iso _TestSessionExecuteBeforeReady is UnitTest
+  fun name(): String =>
+    "integration/Session/ExecuteBeforeReady"
+
+  fun apply(h: TestHelper) =>
+    let info = _RedisTestConfiguration(h.env.vars)
+    let auth = lori.TCPConnectAuth(h.env.root)
+    let client = _ExecuteBeforeReadyClient(h)
+    let session = Session(
+      ConnectInfo(auth, info.host, info.port),
+      client)
+    // Execute immediately — before redis_session_ready fires.
+    let cmd: Array[ByteSeq] val = ["PING"]
+    session.execute(cmd, client)
+    h.dispose_when_done(session)
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _ExecuteBeforeReadyClient is
+  (SessionStatusNotify & ResultReceiver)
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+
+  be redis_command_failed(session: Session,
+    command: Array[ByteSeq] val, failure: ClientError)
+  =>
+    match failure
+    | SessionNotReady =>
+      _h.complete(true)
+    else
+      _h.fail("Expected SessionNotReady, got: " + failure.message())
+      _h.complete(false)
+    end
+
+  be redis_response(session: Session, response: RespValue) =>
+    _h.fail("Should not have received a response")
+    _h.complete(false)
+
+// integration/Session/ExecuteAfterClose
+
+class \nodoc\ iso _TestSessionExecuteAfterClose is UnitTest
+  fun name(): String =>
+    "integration/Session/ExecuteAfterClose"
+
+  fun apply(h: TestHelper) =>
+    let info = _RedisTestConfiguration(h.env.vars)
+    let auth = lori.TCPConnectAuth(h.env.root)
+    let client = _ExecuteAfterCloseClient(h)
+    let session = Session(
+      ConnectInfo(auth, info.host, info.port),
+      client)
+    h.dispose_when_done(session)
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _ExecuteAfterCloseClient is
+  (SessionStatusNotify & ResultReceiver)
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+
+  be redis_session_ready(session: Session) =>
+    session.close()
+    let cmd: Array[ByteSeq] val = ["PING"]
+    session.execute(cmd, this)
+
+  be redis_command_failed(session: Session,
+    command: Array[ByteSeq] val, failure: ClientError)
+  =>
+    match failure
+    | SessionClosed =>
+      _h.complete(true)
+    else
+      _h.fail("Expected SessionClosed, got: " + failure.message())
+      _h.complete(false)
+    end
+
+  be redis_response(session: Session, response: RespValue) =>
+    _h.fail("Should not have received a response")
+    _h.complete(false)
+
+  be redis_session_connection_failed(session: Session) =>
+    _h.fail("Connection failed")
+    _h.complete(false)
+
+// integration/Session/MultipleCommands
+
+class \nodoc\ iso _TestSessionMultipleCommands is UnitTest
+  fun name(): String =>
+    "integration/Session/MultipleCommands"
+
+  fun apply(h: TestHelper) =>
+    let info = _RedisTestConfiguration(h.env.vars)
+    let auth = lori.TCPConnectAuth(h.env.root)
+    let client = _MultipleCommandsClient(h)
+    let session = Session(
+      ConnectInfo(auth, info.host, info.port),
+      client)
+    h.dispose_when_done(session)
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _MultipleCommandsClient is
+  (SessionStatusNotify & ResultReceiver)
+  let _h: TestHelper
+  var _step: USize = 0
+
+  new create(h: TestHelper) =>
+    _h = h
+
+  be redis_session_ready(session: Session) =>
+    let set_cmd: Array[ByteSeq] val =
+      ["SET"; "_test_multi_cmd"; "value1"]
+    session.execute(set_cmd, this)
+    let get_cmd: Array[ByteSeq] val = ["GET"; "_test_multi_cmd"]
+    session.execute(get_cmd, this)
+    let del_cmd: Array[ByteSeq] val = ["DEL"; "_test_multi_cmd"]
+    session.execute(del_cmd, this)
+
+  be redis_response(session: Session, response: RespValue) =>
+    _step = _step + 1
+    match _step
+    | 1 =>
+      // SET response
+      match response
+      | let s: RespSimpleString =>
+        if s.value != "OK" then
+          _h.fail("SET: expected OK, got: " + s.value)
+          _h.complete(false)
+        end
+      else
+        _h.fail("SET: expected RespSimpleString")
+        _h.complete(false)
+      end
+    | 2 =>
+      // GET response
+      match response
+      | let b: RespBulkString =>
+        let value = String.from_array(b.value)
+        if value != "value1" then
+          _h.fail("GET: expected 'value1', got: '" + value + "'")
+          _h.complete(false)
+        end
+      else
+        _h.fail("GET: expected RespBulkString")
+        _h.complete(false)
+      end
+    | 3 =>
+      // DEL response — should be integer 1
+      match response
+      | let i: RespInteger =>
+        if i.value != 1 then
+          _h.fail("DEL: expected 1, got: " + i.value.string())
+          _h.complete(false)
+          return
+        end
+      else
+        _h.fail("DEL: expected RespInteger")
+        _h.complete(false)
+        return
+      end
+      _h.complete(true)
+    else
+      _h.fail("Unexpected response step: " + _step.string())
+      _h.complete(false)
+    end
+
+  be redis_command_failed(session: Session,
+    command: Array[ByteSeq] val, failure: ClientError)
+  =>
+    _h.fail("Command failed: " + failure.message())
+    _h.complete(false)
+
+  be redis_session_connection_failed(session: Session) =>
+    _h.fail("Connection failed")
+    _h.complete(false)
+
+// integration/Session/ServerError
+
+class \nodoc\ iso _TestSessionServerError is UnitTest
+  fun name(): String =>
+    "integration/Session/ServerError"
+
+  fun apply(h: TestHelper) =>
+    let info = _RedisTestConfiguration(h.env.vars)
+    let auth = lori.TCPConnectAuth(h.env.root)
+    let client = _ServerErrorClient(h)
+    let session = Session(
+      ConnectInfo(auth, info.host, info.port),
+      client)
+    h.dispose_when_done(session)
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _ServerErrorClient is (SessionStatusNotify & ResultReceiver)
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+
+  be redis_session_ready(session: Session) =>
+    // Send a command with the wrong number of arguments.
+    let cmd: Array[ByteSeq] val = ["SET"; "only_one_arg"]
+    session.execute(cmd, this)
+
+  be redis_response(session: Session, response: RespValue) =>
+    match response
+    | let e: RespError =>
+      _h.complete(true)
+    else
+      _h.fail("Expected RespError from invalid command")
+      _h.complete(false)
+    end
+
+  be redis_command_failed(session: Session,
+    command: Array[ByteSeq] val, failure: ClientError)
+  =>
+    _h.fail("Command failed: " + failure.message())
+    _h.complete(false)
+
+  be redis_session_connection_failed(session: Session) =>
+    _h.fail("Connection failed")
+    _h.complete(false)

--- a/redis/client_error.pony
+++ b/redis/client_error.pony
@@ -1,0 +1,22 @@
+trait val ClientError
+  """
+  A client-side error that prevented a command from being sent to the server.
+  Each subtype represents a specific pre-condition failure.
+  """
+  fun message(): String
+
+primitive SessionNotReady is ClientError
+  """
+  Error returned when a command is attempted on a session that is not yet
+  ready. This covers sessions that haven't connected, are in the process of
+  connecting, or are authenticating.
+  """
+  fun message(): String => "Session is not ready for commands"
+
+primitive SessionClosed is ClientError
+  """
+  Error returned when a command is attempted on a session that has been
+  closed. Includes sessions closed by the user, by the server, or due to
+  connection or authentication failures.
+  """
+  fun message(): String => "Session is closed"

--- a/redis/connect_info.pony
+++ b/redis/connect_info.pony
@@ -1,0 +1,21 @@
+use lori = "lori"
+
+class val ConnectInfo
+  """
+  Connection configuration for a Redis session.
+
+  Note: Redis AUTH sends the password in plaintext over TCP.
+  Use SSL/TLS when authenticating over untrusted networks.
+  """
+  let auth: lori.TCPConnectAuth
+  let host: String
+  let port: String
+  let password: (String | None)
+
+  new val create(auth': lori.TCPConnectAuth, host': String,
+    port': String = "6379", password': (String | None) = None)
+  =>
+    auth = auth'
+    host = host'
+    port = port'
+    password = password'

--- a/redis/redis.pony
+++ b/redis/redis.pony
@@ -1,6 +1,49 @@
 """
 Redis client for Pony.
 
+## Quick Start
+
+Create a `Session` with connection info and a notification receiver. The
+session connects asynchronously — wait for `redis_session_ready` before
+sending commands:
+
+```pony
+actor MyApp is (SessionStatusNotify & ResultReceiver)
+  let _session: Session
+
+  new create(env: Env) =>
+    let auth = lori.TCPConnectAuth(env.root)
+    _session = Session(ConnectInfo(auth, "localhost"), this)
+
+  be redis_session_ready(session: Session) =>
+    session.execute(["SET"; "key"; "value"], this)
+
+  be redis_response(session: Session, response: RespValue) =>
+    // handle response
+    None
+
+  be redis_command_failed(session: Session,
+    command: Array[ByteSeq] val, failure: ClientError)
+  =>
+    // handle failure
+    None
+```
+
+## Session API
+
+* `ConnectInfo` — connection configuration (host, port, optional password)
+* `Session` — the main entry point; manages connection lifecycle
+* `SessionStatusNotify` — lifecycle callbacks (connected, ready, closed, etc.)
+* `ResultReceiver` — command result callbacks
+
+Commands are arrays of `ByteSeq` (e.g., `["GET", "mykey"]`). Responses are
+`RespValue` variants — including `RespError` for server-side errors.
+
+## Security
+
+Redis AUTH sends the password in plaintext over TCP. Use SSL/TLS when
+authenticating over untrusted networks.
+
 ## RESP2 Value Types
 
 The protocol layer uses `RespValue` as the core type for data exchanged with

--- a/redis/result_receiver.pony
+++ b/redis/result_receiver.pony
@@ -1,0 +1,20 @@
+interface tag ResultReceiver
+  """
+  Receives the result of a Redis command execution. Both callbacks must
+  be implemented — unlike lifecycle events, command results always need
+  to be handled.
+  """
+  be redis_response(session: Session, response: RespValue)
+    """
+    Called when the server responds to a command. The response is the
+    raw RESP value — it may be any variant of `RespValue` including
+    `RespError` for server-side errors (e.g., wrong number of arguments).
+    """
+
+  be redis_command_failed(session: Session,
+    command: Array[ByteSeq] val, failure: ClientError)
+    """
+    Called when a command could not be sent to the server. The command
+    and the client-side error are provided so the caller knows which
+    command failed and why.
+    """

--- a/redis/session.pony
+++ b/redis/session.pony
@@ -1,0 +1,337 @@
+use "buffered"
+use lori = "lori"
+
+actor Session is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
+  """
+  A Redis client session. Manages the connection lifecycle — connecting,
+  optionally authenticating, executing commands, and shutting down — as
+  a state machine.
+
+  Create a session with `ConnectInfo` and a `SessionStatusNotify` receiver.
+  Once `redis_session_ready` fires, commands can be sent via `execute()`.
+  Command execution is serialized: only one command is in flight at a time.
+  Additional calls to `execute()` are queued and dispatched in order.
+  """
+  var state: _SessionState
+  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+
+  new create(connect_info': ConnectInfo, notify': SessionStatusNotify) =>
+    state = _SessionUnopened(notify', connect_info')
+    _tcp_connection = lori.TCPConnection.client(
+      connect_info'.auth,
+      connect_info'.host,
+      connect_info'.port,
+      "",
+      this,
+      this)
+
+  be execute(command: Array[ByteSeq] val, receiver: ResultReceiver) =>
+    """
+    Execute a Redis command. The command is an array of bulk strings
+    (e.g., `["SET", "key", "value"]`). The response is delivered to the
+    receiver via `redis_response` or `redis_command_failed`.
+    """
+    state.execute(this, command, receiver)
+
+  be close() =>
+    """
+    Close the session. Sends a QUIT command to the server before closing
+    the TCP connection. Pending commands receive `SessionClosed` via
+    `redis_command_failed`.
+    """
+    state.close(this)
+
+  // Lori callbacks — delegate to state machine.
+  fun ref _on_connected() =>
+    state.on_connected(this)
+
+  fun ref _on_connection_failure() =>
+    state.on_failure(this)
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    state.on_received(this, consume data)
+
+  fun ref _on_closed() =>
+    state.on_closed(this)
+
+  fun ref _connection(): lori.TCPConnection =>
+    _tcp_connection
+
+// State machine interface
+
+interface _SessionState
+  fun on_connected(s: Session ref)
+  fun on_failure(s: Session ref)
+  fun ref on_received(s: Session ref, data: Array[U8] iso)
+  fun ref on_closed(s: Session ref)
+  fun ref on_response(s: Session ref, response: RespValue)
+  fun ref execute(s: Session ref, command: Array[ByteSeq] val,
+    receiver: ResultReceiver)
+  fun ref close(s: Session ref)
+  fun ref shutdown(s: Session ref)
+
+// Trait composition
+
+trait _ClosedState is _SessionState
+  """
+  Terminal state mixin. All operations are either illegal (protocol
+  anomaly), no-ops (already closed), or error-delivering (execute).
+  """
+  fun on_connected(s: Session ref) =>
+    _IllegalState()
+
+  fun on_failure(s: Session ref) =>
+    _IllegalState()
+
+  fun ref on_received(s: Session ref, data: Array[U8] iso) =>
+    // Data may arrive after close — silently drop.
+    None
+
+  fun ref on_closed(s: Session ref) =>
+    // Already closed.
+    None
+
+  fun ref on_response(s: Session ref, response: RespValue) =>
+    _IllegalState()
+
+  fun ref execute(s: Session ref, command: Array[ByteSeq] val,
+    receiver: ResultReceiver)
+  =>
+    receiver.redis_command_failed(s, command, SessionClosed)
+
+  fun ref close(s: Session ref) =>
+    None
+
+  fun ref shutdown(s: Session ref) =>
+    ifdef debug then
+      _IllegalState()
+    end
+
+trait _ConnectedState is _SessionState
+  """
+  Mixin for states that have a readbuf and process incoming data.
+  Connected states are not connectable — receiving a connect event
+  while already connected is a protocol anomaly.
+
+  All connected states must clear the readbuf before transitioning to
+  `_SessionClosed` on shutdown/error paths. This stops the
+  `_ResponseHandler` loop — the next `_RespParser` call returns `None`
+  and the loop exits naturally.
+  """
+  fun on_connected(s: Session ref) =>
+    _IllegalState()
+
+  fun on_failure(s: Session ref) =>
+    _IllegalState()
+
+  fun ref on_received(s: Session ref, data: Array[U8] iso) =>
+    readbuf().append(consume data)
+    _ResponseHandler(s, readbuf())
+
+  fun ref readbuf(): Reader
+  fun notify(): SessionStatusNotify
+
+trait _NotReadyForCommands is _SessionState
+  """
+  Mixin for states that reject command execution because the session
+  is not yet ready.
+  """
+  fun ref execute(s: Session ref, command: Array[ByteSeq] val,
+    receiver: ResultReceiver)
+  =>
+    receiver.redis_command_failed(s, command, SessionNotReady)
+
+// Session states
+
+class ref _SessionUnopened is _NotReadyForCommands
+  """
+  Initial state — waiting for TCP connection to be established.
+  """
+  let _notify: SessionStatusNotify
+  let _connect_info: ConnectInfo
+
+  new ref create(notify': SessionStatusNotify, connect_info': ConnectInfo) =>
+    _notify = notify'
+    _connect_info = connect_info'
+
+  fun on_connected(s: Session ref) =>
+    _notify.redis_session_connected(s)
+    match _connect_info.password
+    | let password: String =>
+      let st = _SessionConnected(_notify)
+      s.state = st
+      let cmd: Array[ByteSeq] val = ["AUTH"; password]
+      s._connection().send(_RespSerializer(cmd))
+    | None =>
+      s.state = _SessionReady(_notify)
+      _notify.redis_session_ready(s)
+    end
+
+  fun on_failure(s: Session ref) =>
+    s.state = _SessionClosed
+    _notify.redis_session_connection_failed(s)
+
+  fun ref on_received(s: Session ref, data: Array[U8] iso) =>
+    _IllegalState()
+
+  fun ref on_response(s: Session ref, response: RespValue) =>
+    _IllegalState()
+
+  fun ref on_closed(s: Session ref) =>
+    // Defensive — lori fires _on_closed only for established connections,
+    // so this is unlikely to be reached from _SessionUnopened.
+    s.state = _SessionClosed
+    _notify.redis_session_closed(s)
+
+  fun ref close(s: Session ref) =>
+    s._connection().close()
+
+  fun ref shutdown(s: Session ref) =>
+    s._connection().close()
+
+class ref _SessionConnected is (_ConnectedState & _NotReadyForCommands)
+  """
+  TCP connected, AUTH command sent, waiting for the server's response.
+
+  AUTH is sent from `_SessionUnopened.on_connected` after transitioning
+  to this state (not from the constructor — constructors don't have
+  `Session ref`).
+  """
+  let _notify: SessionStatusNotify
+  let _readbuf: Reader = _readbuf.create()
+
+  new ref create(notify': SessionStatusNotify) =>
+    _notify = notify'
+
+  fun ref on_response(s: Session ref, response: RespValue) =>
+    match response
+    | let ok: RespSimpleString if ok.value == "OK" =>
+      s.state = _SessionReady.from_connected(_notify, _readbuf)
+      _notify.redis_session_ready(s)
+    | let err: RespError =>
+      _notify.redis_session_authentication_failed(s, err.message)
+      shutdown(s)
+    else
+      // Unexpected AUTH response — protocol violation.
+      shutdown(s)
+    end
+
+  fun ref on_closed(s: Session ref) =>
+    _readbuf.clear()
+    s.state = _SessionClosed
+    _notify.redis_session_closed(s)
+
+  fun ref close(s: Session ref) =>
+    s._connection().close()
+
+  fun ref shutdown(s: Session ref) =>
+    _readbuf.clear()
+    s._connection().close()
+    s.state = _SessionClosed
+    _notify.redis_session_closed(s)
+
+  fun ref readbuf(): Reader =>
+    _readbuf
+
+  fun notify(): SessionStatusNotify =>
+    _notify
+
+class val _QueuedCommand
+  """
+  A command waiting to be sent or awaiting its response.
+  """
+  let command: Array[ByteSeq] val
+  let receiver: ResultReceiver
+
+  new val create(command': Array[ByteSeq] val,
+    receiver': ResultReceiver)
+  =>
+    command = command'
+    receiver = receiver'
+
+class ref _SessionReady is _ConnectedState
+  """
+  Session is ready to execute commands. Command execution is serialized:
+  only one command is in flight at a time. Additional calls to `execute()`
+  are queued and dispatched in order. Phase 3 (pipelining) will remove
+  the in-flight gate.
+  """
+  let _notify: SessionStatusNotify
+  let _readbuf: Reader
+  let _pending: Array[_QueuedCommand] = _pending.create()
+  var _in_flight: Bool = false
+
+  new ref create(notify': SessionStatusNotify) =>
+    _notify = notify'
+    _readbuf = Reader
+
+  new ref from_connected(notify': SessionStatusNotify, readbuf': Reader) =>
+    _notify = notify'
+    _readbuf = readbuf'
+
+  fun ref execute(s: Session ref, command: Array[ByteSeq] val,
+    receiver: ResultReceiver)
+  =>
+    _pending.push(_QueuedCommand(command, receiver))
+    if not _in_flight then
+      _send_next(s)
+    end
+
+  fun ref on_response(s: Session ref, response: RespValue) =>
+    try
+      let queued = _pending.shift()?
+      _in_flight = false
+      queued.receiver.redis_response(s, response)
+      if _pending.size() > 0 then
+        _send_next(s)
+      end
+    else
+      _Unreachable()
+    end
+
+  fun ref on_closed(s: Session ref) =>
+    _readbuf.clear()
+    _drain_pending(s)
+    s.state = _SessionClosed
+    _notify.redis_session_closed(s)
+
+  fun ref close(s: Session ref) =>
+    _drain_pending(s)
+    _readbuf.clear()
+    s._connection().send(_RespSerializer(["QUIT"]))
+    s._connection().close()
+    s.state = _SessionClosed
+    _notify.redis_session_closed(s)
+
+  fun ref shutdown(s: Session ref) =>
+    _readbuf.clear()
+    _drain_pending(s)
+    s._connection().close()
+    s.state = _SessionClosed
+    _notify.redis_session_closed(s)
+
+  fun ref readbuf(): Reader =>
+    _readbuf
+
+  fun notify(): SessionStatusNotify =>
+    _notify
+
+  fun ref _send_next(s: Session ref) =>
+    try
+      let queued = _pending(0)?
+      s._connection().send(_RespSerializer(queued.command))
+      _in_flight = true
+    else
+      _Unreachable()
+    end
+
+  fun ref _drain_pending(s: Session ref) =>
+    for queued in _pending.values() do
+      queued.receiver.redis_command_failed(s, queued.command, SessionClosed)
+    end
+    _pending.clear()
+
+class ref _SessionClosed is _ClosedState
+  """
+  Terminal state. The session is closed and cannot be reused.
+  """

--- a/redis/session_status_notify.pony
+++ b/redis/session_status_notify.pony
@@ -1,0 +1,44 @@
+interface tag SessionStatusNotify
+  """
+  Receives session lifecycle events: connection, authentication, and
+  shutdown. All callbacks have default no-op implementations, so consumers
+  only need to override the events they care about.
+  """
+  be redis_session_connected(session: Session) =>
+    """
+    Called when the TCP connection to the server is established. This is
+    informational — the session is not yet ready for commands. Wait for
+    `redis_session_ready` before sending commands.
+    """
+    None
+
+  be redis_session_connection_failed(session: Session) =>
+    """
+    Called when the TCP connection to the server fails. The session is
+    terminal after this callback.
+    """
+    None
+
+  be redis_session_ready(session: Session) =>
+    """
+    Called when the session is ready to accept commands. Fires after
+    successful AUTH when a password is configured, or immediately after
+    TCP connect when no password is set.
+    """
+    None
+
+  be redis_session_authentication_failed(session: Session,
+    message: String)
+  =>
+    """
+    Called when the AUTH command returns an error. The session closes
+    after this callback.
+    """
+    None
+
+  be redis_session_closed(session: Session) =>
+    """
+    Called when the session has closed, whether by user request, server
+    disconnect, or error.
+    """
+    None


### PR DESCRIPTION
Implements Phase 2 from the design in Discussion #2. Adds the Session actor
which manages the full Redis connection lifecycle as a state machine,
following the ponylang/postgres session pattern.

**New public types:**
- `Session` — main entry point; connect, execute commands, close
- `ConnectInfo` — connection configuration (host, port, optional password)
- `SessionStatusNotify` — lifecycle callbacks (connected, ready, closed, etc.)
- `ResultReceiver` — command result callbacks (`redis_response`, `redis_command_failed`)
- `ClientError` / `SessionNotReady` / `SessionClosed` — client-side error types

**State machine:** `_SessionUnopened` → `_SessionConnected` (AUTH) → `_SessionReady` → `_SessionClosed`

Command execution is serialized one-at-a-time with a pending queue (Phase 3 adds pipelining).

**Infrastructure:**
- Adds lori 0.8.1 dependency (requires `ssl=` build flag)
- CI uses libressl builder image with Redis 7 service container
- Makefile gains `integration-tests`, `start-redis`, `stop-redis` targets
- 7 integration tests covering connect, SET/GET, connection failure, execute-before-ready, execute-after-close, multiple commands, and server errors

Design: #2