### PR TITLE
Add pipelining to Session command execution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ _SessionConnected ──AUTH OK──► _SessionReady
 _SessionReady ──close/error──► _SessionClosed
 ```
 
-Command execution in `_SessionReady` is serialized: one command in flight at a time, with a queue for pending commands.
+Commands are pipelined in `_SessionReady`: each `execute()` call sends the command immediately over the wire without waiting for prior responses. Responses are matched to receivers in FIFO order.
 
 ## Test Infrastructure
 

--- a/examples/pipeline/main.pony
+++ b/examples/pipeline/main.pony
@@ -1,0 +1,80 @@
+use "cli"
+use lori = "lori"
+// in your code this `use` statement would be:
+// use "redis"
+use "../../redis"
+
+actor Main
+  new create(env: Env) =>
+    let info = ServerInfo(env.vars)
+    let auth = lori.TCPConnectAuth(env.root)
+    Client(auth, info, env.out)
+
+actor Client is (SessionStatusNotify & ResultReceiver)
+  let _session: Session
+  let _out: OutStream
+  var _step: USize = 0
+
+  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+    _out = out
+    _session = Session(
+      ConnectInfo(auth, info.host, info.port),
+      this)
+
+  be redis_session_ready(session: Session) =>
+    _out.print("Connected and ready.")
+
+    // Pipeline 3 SET commands — all sent immediately without waiting
+    // for individual responses.
+    _out.print("Pipelining SET commands...")
+    let fruits: Array[String] val = ["apple"; "banana"; "cherry"]
+    for fruit in fruits.values() do
+      let cmd: Array[ByteSeq] val = ["SET"; "fruit:" + fruit; fruit]
+      session.execute(cmd, this)
+    end
+
+    // Pipeline 3 GET commands to retrieve the values we just set.
+    _out.print("Pipelining GET commands...")
+    for fruit in fruits.values() do
+      let cmd: Array[ByteSeq] val = ["GET"; "fruit:" + fruit]
+      session.execute(cmd, this)
+    end
+
+  be redis_session_connection_failed(session: Session) =>
+    _out.print("Failed to connect.")
+
+  be redis_response(session: Session, response: RespValue) =>
+    _step = _step + 1
+    if _step <= 3 then
+      match response
+      | let s: RespSimpleString => _out.print("SET response: " + s.value)
+      | let e: RespError => _out.print("SET error: " + e.message)
+      end
+    elseif _step <= 6 then
+      match response
+      | let b: RespBulkString =>
+        _out.print("GET response: " + String.from_array(b.value))
+      | let e: RespError => _out.print("GET error: " + e.message)
+      end
+    end
+    if _step == 6 then
+      _out.print("All responses received.")
+      _session.close()
+    end
+
+  be redis_command_failed(session: Session,
+    command: Array[ByteSeq] val, failure: ClientError)
+  =>
+    _out.print("Command failed: " + failure.message())
+    _session.close()
+
+class val ServerInfo
+  let host: String
+  let port: String
+
+  new val create(vars: (Array[String] val | None)) =>
+    let e = EnvVars(vars)
+    host = try e("REDIS_HOST")? else
+      ifdef linux then "127.0.0.2" else "localhost" end
+    end
+    port = try e("REDIS_PORT")? else "6379" end

--- a/redis/_test.pony
+++ b/redis/_test.pony
@@ -42,4 +42,7 @@ actor \nodoc\ Main is TestList
     test(_TestSessionExecuteBeforeReady)
     test(_TestSessionExecuteAfterClose)
     test(_TestSessionMultipleCommands)
+    test(_TestSessionPipeline)
+    test(_TestSessionPipelineMixedResponses)
+    test(_TestSessionPipelineClose)
     test(_TestSessionServerError)

--- a/redis/_test_session.pony
+++ b/redis/_test_session.pony
@@ -1,4 +1,5 @@
 use "cli"
+use "collections"
 use lori = "lori"
 use "pony_test"
 
@@ -323,6 +324,245 @@ actor \nodoc\ _MultipleCommandsClient is
   =>
     _h.fail("Command failed: " + failure.message())
     _h.complete(false)
+
+  be redis_session_connection_failed(session: Session) =>
+    _h.fail("Connection failed")
+    _h.complete(false)
+
+// integration/Session/Pipeline
+
+class \nodoc\ iso _TestSessionPipeline is UnitTest
+  fun name(): String =>
+    "integration/Session/Pipeline"
+
+  fun apply(h: TestHelper) =>
+    let info = _RedisTestConfiguration(h.env.vars)
+    let auth = lori.TCPConnectAuth(h.env.root)
+    let client = _PipelineClient(h)
+    let session = Session(
+      ConnectInfo(auth, info.host, info.port),
+      client)
+    h.dispose_when_done(session)
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _PipelineClient is (SessionStatusNotify & ResultReceiver)
+  let _h: TestHelper
+  var _step: USize = 0
+
+  new create(h: TestHelper) =>
+    _h = h
+
+  be redis_session_ready(session: Session) =>
+    // Pipeline 5 SET commands at once.
+    for i in Range(0, 5) do
+      let key: String val = "_test_pipeline_" + i.string()
+      let value: String val = "value_" + i.string()
+      let cmd: Array[ByteSeq] val = ["SET"; key; value]
+      session.execute(cmd, this)
+    end
+    // Then pipeline 5 GET commands.
+    for i in Range(0, 5) do
+      let key: String val = "_test_pipeline_" + i.string()
+      let cmd: Array[ByteSeq] val = ["GET"; key]
+      session.execute(cmd, this)
+    end
+
+  be redis_response(session: Session, response: RespValue) =>
+    _step = _step + 1
+    if _step <= 5 then
+      // SET responses — all should be +OK
+      match response
+      | let s: RespSimpleString =>
+        if s.value != "OK" then
+          _h.fail("SET: expected OK, got: " + s.value)
+          _h.complete(false)
+        end
+      else
+        _h.fail("SET: expected RespSimpleString")
+        _h.complete(false)
+      end
+    elseif _step <= 10 then
+      // GET responses — should match the values we set.
+      let i = _step - 6
+      let expected: String val = "value_" + i.string()
+      match response
+      | let b: RespBulkString =>
+        let value = String.from_array(b.value)
+        if value != expected then
+          _h.fail("GET: expected '" + expected + "', got: '" + value + "'")
+          _h.complete(false)
+        end
+      else
+        _h.fail("GET: expected RespBulkString")
+        _h.complete(false)
+      end
+      if _step == 10 then
+        // Clean up test keys.
+        for j in Range(0, 5) do
+          let key: String val = "_test_pipeline_" + j.string()
+          let cmd: Array[ByteSeq] val = ["DEL"; key]
+          session.execute(cmd, this)
+        end
+      end
+    elseif _step == 15 then
+      // All DEL responses received — done.
+      _h.complete(true)
+    end
+
+  be redis_command_failed(session: Session,
+    command: Array[ByteSeq] val, failure: ClientError)
+  =>
+    _h.fail("Command failed: " + failure.message())
+    _h.complete(false)
+
+  be redis_session_connection_failed(session: Session) =>
+    _h.fail("Connection failed")
+    _h.complete(false)
+
+// integration/Session/PipelineMixedResponses
+
+class \nodoc\ iso _TestSessionPipelineMixedResponses is UnitTest
+  fun name(): String =>
+    "integration/Session/PipelineMixedResponses"
+
+  fun apply(h: TestHelper) =>
+    let info = _RedisTestConfiguration(h.env.vars)
+    let auth = lori.TCPConnectAuth(h.env.root)
+    let client = _PipelineMixedClient(h)
+    let session = Session(
+      ConnectInfo(auth, info.host, info.port),
+      client)
+    h.dispose_when_done(session)
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _PipelineMixedClient is (SessionStatusNotify & ResultReceiver)
+  let _h: TestHelper
+  var _step: USize = 0
+
+  new create(h: TestHelper) =>
+    _h = h
+
+  be redis_session_ready(session: Session) =>
+    // Pipeline three commands: SET (OK), invalid (ERR), GET (bulk string).
+    let set_cmd: Array[ByteSeq] val =
+      ["SET"; "_test_pipeline_mixed"; "hello"]
+    session.execute(set_cmd, this)
+    // SET with wrong arity produces -ERR.
+    let bad_cmd: Array[ByteSeq] val = ["SET"; "only_one_arg"]
+    session.execute(bad_cmd, this)
+    let get_cmd: Array[ByteSeq] val = ["GET"; "_test_pipeline_mixed"]
+    session.execute(get_cmd, this)
+
+  be redis_response(session: Session, response: RespValue) =>
+    _step = _step + 1
+    match _step
+    | 1 =>
+      // SET response — should be +OK
+      match response
+      | let s: RespSimpleString =>
+        if s.value != "OK" then
+          _h.fail("SET: expected OK, got: " + s.value)
+          _h.complete(false)
+        end
+      else
+        _h.fail("SET: expected RespSimpleString")
+        _h.complete(false)
+      end
+    | 2 =>
+      // Invalid command — should be RespError
+      match response
+      | let _: RespError => None
+      else
+        _h.fail("Invalid command: expected RespError")
+        _h.complete(false)
+      end
+    | 3 =>
+      // GET response — should be bulk string "hello"
+      match response
+      | let b: RespBulkString =>
+        let value = String.from_array(b.value)
+        if value != "hello" then
+          _h.fail("GET: expected 'hello', got: '" + value + "'")
+          _h.complete(false)
+          return
+        end
+      else
+        _h.fail("GET: expected RespBulkString")
+        _h.complete(false)
+        return
+      end
+      // Clean up test key.
+      let del_cmd: Array[ByteSeq] val = ["DEL"; "_test_pipeline_mixed"]
+      session.execute(del_cmd, this)
+    | 4 =>
+      // DEL response — done.
+      _h.complete(true)
+    else
+      _h.fail("Unexpected response step: " + _step.string())
+      _h.complete(false)
+    end
+
+  be redis_command_failed(session: Session,
+    command: Array[ByteSeq] val, failure: ClientError)
+  =>
+    _h.fail("Command failed: " + failure.message())
+    _h.complete(false)
+
+  be redis_session_connection_failed(session: Session) =>
+    _h.fail("Connection failed")
+    _h.complete(false)
+
+// integration/Session/PipelineClose
+
+class \nodoc\ iso _TestSessionPipelineClose is UnitTest
+  fun name(): String =>
+    "integration/Session/PipelineClose"
+
+  fun apply(h: TestHelper) =>
+    let info = _RedisTestConfiguration(h.env.vars)
+    let auth = lori.TCPConnectAuth(h.env.root)
+    let client = _PipelineCloseClient(h)
+    let session = Session(
+      ConnectInfo(auth, info.host, info.port),
+      client)
+    h.dispose_when_done(session)
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _PipelineCloseClient is (SessionStatusNotify & ResultReceiver)
+  let _h: TestHelper
+  var _callback_count: USize = 0
+
+  new create(h: TestHelper) =>
+    _h = h
+
+  be redis_session_ready(session: Session) =>
+    // Pipeline 5 SET commands and immediately close.
+    for i in Range(0, 5) do
+      let key: String val = "_test_pipeline_close_" + i.string()
+      let cmd: Array[ByteSeq] val = ["SET"; key; "value"]
+      session.execute(cmd, this)
+    end
+    session.close()
+
+  be redis_response(session: Session, response: RespValue) =>
+    _callback_count = _callback_count + 1
+    if _callback_count == 5 then
+      _h.complete(true)
+    end
+
+  be redis_command_failed(session: Session,
+    command: Array[ByteSeq] val, failure: ClientError)
+  =>
+    match failure
+    | SessionClosed =>
+      _callback_count = _callback_count + 1
+      if _callback_count == 5 then
+        _h.complete(true)
+      end
+    else
+      _h.fail("Expected SessionClosed, got: " + failure.message())
+      _h.complete(false)
+    end
 
   be redis_session_connection_failed(session: Session) =>
     _h.fail("Connection failed")


### PR DESCRIPTION
Phase 2 serialized command execution: one command in flight at a time, with subsequent commands queued until the response arrived. Phase 3 removes this gate — each call to `execute()` sends the command immediately over the wire, and responses are matched to receivers in FIFO order. This is the natural behavior of the Redis protocol and enables significantly higher throughput for workloads that issue many commands.

The change is transparent to callers: the `execute()` API is unchanged. Users who want serialized behavior can still wait for each response before sending the next command.

Design: #2