### PR TITLE
Add Pub/Sub support

### DIFF
--- a/examples/pubsub/main.pony
+++ b/examples/pubsub/main.pony
@@ -1,0 +1,95 @@
+use "cli"
+use lori = "lori"
+// in your code this `use` statement would be:
+// use "redis"
+use "../../redis"
+
+actor Main
+  new create(env: Env) =>
+    let info = ServerInfo(env.vars)
+    let auth = lori.TCPConnectAuth(env.root)
+    PubSubDemo(auth, info, env.out)
+
+actor PubSubDemo is
+  (SessionStatusNotify & SubscriptionNotify & ResultReceiver)
+  let _subscriber: Session
+  let _publisher: Session
+  let _out: OutStream
+  var _subscriber_ready: Bool = false
+  var _publisher_ready: Bool = false
+
+  new create(auth: lori.TCPConnectAuth, info: ServerInfo,
+    out: OutStream)
+  =>
+    _out = out
+    _subscriber = Session(
+      ConnectInfo(auth, info.host, info.port),
+      this)
+    _publisher = Session(
+      ConnectInfo(auth, info.host, info.port),
+      this)
+
+  be redis_session_ready(session: Session) =>
+    if session is _subscriber then
+      _subscriber_ready = true
+    elseif session is _publisher then
+      _publisher_ready = true
+    end
+    if _subscriber_ready and _publisher_ready then
+      _out.print("Both sessions ready. Subscribing to 'demo-channel'...")
+      let channels: Array[String] val = ["demo-channel"]
+      _subscriber.subscribe(channels, this)
+    end
+
+  be redis_subscribed(session: Session, channel: String,
+    count: USize)
+  =>
+    _out.print("Subscribed to '" + channel + "' (active: "
+      + count.string() + ")")
+    _out.print("Publishing a message...")
+    let cmd: Array[ByteSeq] val =
+      ["PUBLISH"; "demo-channel"; "Hello from Pony!"]
+    _publisher.execute(cmd, this)
+
+  be redis_message(session: Session, channel: String,
+    data: Array[U8] val)
+  =>
+    _out.print("Received message on '" + channel + "': "
+      + String.from_array(data))
+    _out.print("Unsubscribing...")
+    let channels: Array[String] val = ["demo-channel"]
+    _subscriber.unsubscribe(channels)
+
+  be redis_unsubscribed(session: Session, channel: String,
+    count: USize)
+  =>
+    _out.print("Unsubscribed from '" + channel + "' (remaining: "
+      + count.string() + ")")
+    _subscriber.close()
+    _publisher.close()
+
+  be redis_session_connection_failed(session: Session) =>
+    _out.print("Failed to connect.")
+
+  be redis_response(session: Session, response: RespValue) =>
+    match response
+    | let i: RespInteger =>
+      _out.print("Message delivered to " + i.value.string()
+        + " subscriber(s).")
+    end
+
+  be redis_command_failed(session: Session,
+    command: Array[ByteSeq] val, failure: ClientError)
+  =>
+    _out.print("Command failed: " + failure.message())
+
+class val ServerInfo
+  let host: String
+  let port: String
+
+  new val create(vars: (Array[String] val | None)) =>
+    let e = EnvVars(vars)
+    host = try e("REDIS_HOST")? else
+      ifdef linux then "127.0.0.2" else "localhost" end
+    end
+    port = try e("REDIS_PORT")? else "6379" end

--- a/redis/_test.pony
+++ b/redis/_test.pony
@@ -46,3 +46,7 @@ actor \nodoc\ Main is TestList
     test(_TestSessionPipelineMixedResponses)
     test(_TestSessionPipelineClose)
     test(_TestSessionServerError)
+    test(_TestSessionPubSub)
+    test(_TestSessionPubSubPattern)
+    test(_TestSessionExecuteWhileSubscribed)
+    test(_TestSessionPubSubBackToReady)

--- a/redis/client_error.pony
+++ b/redis/client_error.pony
@@ -20,3 +20,12 @@ primitive SessionClosed is ClientError
   connection or authentication failures.
   """
   fun message(): String => "Session is closed"
+
+primitive SessionInSubscribedMode is ClientError
+  """
+  Error returned when `execute()` is called on a session that is in
+  pub/sub subscribed mode. Commands cannot be sent while subscribed —
+  unsubscribe from all channels and patterns first, or use a separate
+  session for commands.
+  """
+  fun message(): String => "Session is in subscribed mode"

--- a/redis/session_status_notify.pony
+++ b/redis/session_status_notify.pony
@@ -23,7 +23,8 @@ interface tag SessionStatusNotify
     """
     Called when the session is ready to accept commands. Fires after
     successful AUTH when a password is configured, or immediately after
-    TCP connect when no password is set.
+    TCP connect when no password is set. Also fires when the session
+    exits pub/sub subscribed mode (subscription count reaches 0).
     """
     None
 

--- a/redis/subscription_notify.pony
+++ b/redis/subscription_notify.pony
@@ -1,0 +1,69 @@
+interface tag SubscriptionNotify
+  """
+  Receives pub/sub events: subscription confirmations, incoming messages,
+  and unsubscription confirmations. All callbacks have default no-op
+  implementations, so consumers only need to override the events they
+  care about.
+
+  When a subscribed session closes (voluntarily or due to error), this
+  interface receives no notification — messages simply stop arriving.
+  Implement `SessionStatusNotify` alongside this interface to detect
+  connection loss during subscribed mode.
+  """
+  be redis_subscribed(session: Session, channel: String, count: USize) =>
+    """
+    Called when a channel subscription is confirmed by the server. The
+    count is the total number of active subscriptions (channels and
+    patterns combined).
+    """
+    None
+
+  be redis_unsubscribed(session: Session, channel: String, count: USize) =>
+    """
+    Called when a channel unsubscription is confirmed by the server. The
+    count is the total number of remaining active subscriptions. When
+    count reaches 0, the session exits subscribed mode and
+    `redis_session_ready` fires on the `SessionStatusNotify`.
+    """
+    None
+
+  be redis_message(session: Session, channel: String,
+    data: Array[U8] val)
+  =>
+    """
+    Called when a message is received on a subscribed channel. The data
+    is raw bytes because Redis pub/sub messages can contain arbitrary
+    binary data.
+    """
+    None
+
+  be redis_psubscribed(session: Session, pattern: String,
+    count: USize)
+  =>
+    """
+    Called when a pattern subscription is confirmed by the server. The
+    count is the total number of active subscriptions (channels and
+    patterns combined).
+    """
+    None
+
+  be redis_punsubscribed(session: Session, pattern: String,
+    count: USize)
+  =>
+    """
+    Called when a pattern unsubscription is confirmed by the server. The
+    count is the total number of remaining active subscriptions. When
+    count reaches 0, the session exits subscribed mode and
+    `redis_session_ready` fires on the `SessionStatusNotify`.
+    """
+    None
+
+  be redis_pmessage(session: Session, pattern: String, channel: String,
+    data: Array[U8] val)
+  =>
+    """
+    Called when a message is received matching a subscribed pattern. The
+    pattern is the glob that matched, the channel is the actual channel
+    the message was published to, and the data is raw bytes.
+    """
+    None


### PR DESCRIPTION
Adds SUBSCRIBE, UNSUBSCRIBE, PSUBSCRIBE, and PUNSUBSCRIBE support via a new `_SessionSubscribed` state in the session state machine.

New public API:
- `SubscriptionNotify` interface with 6 callbacks (`redis_subscribed`, `redis_unsubscribed`, `redis_message`, `redis_psubscribed`, `redis_punsubscribed`, `redis_pmessage`)
- `Session.subscribe()`, `Session.unsubscribe()`, `Session.psubscribe()`, `Session.punsubscribe()` behaviors
- `SessionInSubscribedMode` error primitive for `execute()` rejection while subscribed

The subscribed state drains any in-flight pipelined commands before switching to pub/sub message routing (relying on Redis's in-order response guarantee), and transitions back to `_SessionReady` when the total subscription count reaches 0.

Includes 4 integration tests (channel pub/sub, pattern pub/sub, execute rejection, ready-subscribe-ready lifecycle) and a pubsub example.

Design: #2