### PR TITLE
Add integration test for pending-command drain in subscribed mode

### DIFF
--- a/redis/_test.pony
+++ b/redis/_test.pony
@@ -50,3 +50,4 @@ actor \nodoc\ Main is TestList
     test(_TestSessionPubSubPattern)
     test(_TestSessionExecuteWhileSubscribed)
     test(_TestSessionPubSubBackToReady)
+    test(_TestSessionPipelineDrain)


### PR DESCRIPTION
Exercises the drain path in `_SessionSubscribed.on_response` that was documented with a coupling comment but had no test coverage. The test pipelines SET + GET commands, immediately subscribes, then verifies the pipelined responses are delivered via the original `ResultReceiver` (drain) and the subscribe confirmation arrives via `SubscriptionNotify` (pub/sub routing resumes after drain).

Closes #8