### PR TITLE
Add positive boundary test for I64.max in _read_line_as_i64

### DIFF
--- a/redis/_test_resp_parser.pony
+++ b/redis/_test_resp_parser.pony
@@ -446,6 +446,19 @@ class \nodoc\ iso _TestRespParserIntegerOverflow is UnitTest
       _build_header('$', "-9223372036854775809"),
       "Negative overflow should be malformed")
 
+    // I64.max as bulk string length should be accepted by _read_line_as_i64
+    // (returns None because the buffer lacks the data bytes, not RespMalformed)
+    let max_buf: Reader = Reader
+    max_buf.append(_build_header('$', I64.max_value().string()))
+    match _RespParser(max_buf)
+    | None => None
+    | let m: RespMalformed =>
+      h.fail("I64.max as bulk string length should not be malformed: "
+        + m.message)
+    | let _: RespValue =>
+      h.fail("I64.max as bulk string length should be incomplete, not a value")
+    end
+
   fun _build_header(type_byte: U8, value: String): Array[U8] val =>
     recover val
       let a = Array[U8]


### PR DESCRIPTION
The overflow tests from #10 only verified that values exceeding I64 range are rejected as `RespMalformed` (failure side of the boundary). This adds the complementary test: `I64.max_value()` as a bulk string length should be accepted by `_read_line_as_i64`, returning `None` (incomplete) since the buffer lacks the data bytes.

Together with the existing overflow tests, this defines the exact acceptance boundary for the integer accumulator.