### PR TITLE
Add RESP3 protocol support

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -29,6 +29,13 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      redis-resp2:
+        image: redis:5
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Unit tests
@@ -40,6 +47,8 @@ jobs:
           REDIS_PORT: 6379
           REDIS_SSL_HOST: redis-ssl
           REDIS_SSL_PORT: 6379
+          REDIS_RESP2_HOST: redis-resp2
+          REDIS_RESP2_PORT: 6379
       - name: Build examples
         run: make build-examples config=debug ssl=libressl
       - name: Send alert on failure

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,6 +55,13 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      redis-resp2:
+        image: redis:5
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Unit tests
@@ -66,5 +73,7 @@ jobs:
           REDIS_PORT: 6379
           REDIS_SSL_HOST: redis-ssl
           REDIS_SSL_PORT: 6379
+          REDIS_RESP2_HOST: redis-resp2
+          REDIS_RESP2_PORT: 6379
       - name: Build examples
         run: make build-examples config=debug ssl=libressl

--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,10 @@ start-redis:
 		-p 6380:6379 \
 		-d --entrypoint sh redis:7 \
 		-c "cp /tls/redis.key.orig /tls/redis.key && chmod 600 /tls/redis.key && exec redis-server --tls-port 6379 --port 0 --tls-cert-file /tls/redis.crt --tls-key-file /tls/redis.key --tls-auth-clients no"
+	@docker run --name redis-resp2 -p 6381:6379 -d redis:5
 
 stop-redis:
-	@docker stop redis redis-ssl && docker rm redis redis-ssl
+	@docker stop redis redis-ssl redis-resp2 && docker rm redis redis-ssl redis-resp2
 
 $(tests_binary): $(SOURCE_FILES) | $(BUILD_DIR)
 	$(GET_DEPENDENCIES_WITH)

--- a/examples/resp3/main.pony
+++ b/examples/resp3/main.pony
@@ -1,0 +1,89 @@
+use "cli"
+use lori = "lori"
+// in your code this `use` statement would be:
+// use "redis"
+use "../../redis"
+
+actor Main
+  new create(env: Env) =>
+    let info = ServerInfo(env.vars)
+    let auth = lori.TCPConnectAuth(env.root)
+    Client(auth, info, env.out)
+
+actor Client is (SessionStatusNotify & ResultReceiver)
+  let _session: Session
+  let _out: OutStream
+  var _step: USize = 0
+
+  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+    _out = out
+    _session = Session(
+      ConnectInfo(auth, info.host, info.port where protocol' = Resp3),
+      this)
+
+  be redis_session_ready(session: Session) =>
+    _out.print("Connected with RESP3 protocol.")
+    // HSET writes fields on a hash key.
+    let cmd: Array[ByteSeq] val =
+      ["HSET"; "_resp3_example"; "name"; "Pony"; "version"; "0.60"]
+    session.execute(cmd, this)
+
+  be redis_session_connection_failed(session: Session) =>
+    _out.print("Failed to connect.")
+
+  be redis_response(session: Session, response: RespValue) =>
+    _step = _step + 1
+    if _step == 1 then
+      // HSET response — integer count of fields added.
+      _out.print("HSET done.")
+      // HGETALL returns a map in RESP3 mode.
+      let cmd: Array[ByteSeq] val = ["HGETALL"; "_resp3_example"]
+      session.execute(cmd, this)
+    elseif _step == 2 then
+      // HGETALL response — RespMap in RESP3, RespArray in RESP2.
+      match response
+      | let m: RespMap =>
+        _out.print("HGETALL returned a map with "
+          + m.pairs.size().string() + " pairs:")
+        for (k, v) in m.pairs.values() do
+          let ks = match k
+          | let b: RespBulkString => String.from_array(b.value)
+          else "?"
+          end
+          let vs = match v
+          | let b: RespBulkString => String.from_array(b.value)
+          else "?"
+          end
+          _out.print("  " + ks + " = " + vs)
+        end
+      | let a: RespArray =>
+        // Fallback to RESP2 — server didn't support HELLO.
+        _out.print("HGETALL returned an array (RESP2 fallback) with "
+          + a.values.size().string() + " elements.")
+      else
+        _out.print("Unexpected response type from HGETALL.")
+      end
+      // Clean up.
+      let cmd: Array[ByteSeq] val = ["DEL"; "_resp3_example"]
+      session.execute(cmd, this)
+    else
+      _out.print("Cleaned up. Done.")
+      _session.close()
+    end
+
+  be redis_command_failed(session: Session,
+    command: Array[ByteSeq] val, failure: ClientError)
+  =>
+    _out.print("Command failed: " + failure.message())
+    _session.close()
+
+class val ServerInfo
+  let host: String
+  let port: String
+
+  new val create(vars: (Array[String] val | None)) =>
+    let e = EnvVars(vars)
+    host = try e("REDIS_HOST")? else
+      ifdef linux then "127.0.0.2" else "localhost" end
+    end
+    port = try e("REDIS_PORT")? else "6379" end

--- a/redis/_resp_parser.pony
+++ b/redis/_resp_parser.pony
@@ -2,8 +2,8 @@ use "buffered"
 
 primitive _RespParser
   """
-  Parse a single RESP2 value from the buffer. Returns the parsed value if a
-  complete message is available, None if the buffer contains an incomplete
+  Parse a single RESP2/RESP3 value from the buffer. Returns the parsed value
+  if a complete message is available, None if the buffer contains an incomplete
   message, or RespMalformed if the buffer contains invalid data.
 
   The buffer is only modified when a complete value is successfully parsed.
@@ -38,11 +38,24 @@ primitive _RespParser
     else return RespMalformed("unexpected end of buffer") end
 
     match type_byte
+    // RESP2 types
     | '+' => _line_size(buffer, offset)
     | '-' => _line_size(buffer, offset)
     | ':' => _line_size(buffer, offset)
     | '$' => _bulk_string_size(buffer, offset)
     | '*' => _array_size(buffer, offset)
+    // RESP3 simple types (line-terminated)
+    | '_' => _line_size(buffer, offset)
+    | '#' => _line_size(buffer, offset)
+    | ',' => _line_size(buffer, offset)
+    | '(' => _line_size(buffer, offset)
+    // RESP3 bulk types (length-prefixed)
+    | '!' => _bulk_string_size(buffer, offset)
+    | '=' => _bulk_string_size(buffer, offset)
+    // RESP3 aggregate types
+    | '%' => _map_size(buffer, offset)
+    | '~' => _array_size(buffer, offset)
+    | '>' => _array_size(buffer, offset)
     else
       RespMalformed("unknown RESP type byte: " + type_byte.string())
     end
@@ -82,6 +95,7 @@ primitive _RespParser
     """
     Determine size of a bulk string at offset.
     Format: $<length>\r\n<data>\r\n  or  $-1\r\n for null.
+    Also used for RESP3 bulk error (!) and verbatim string (=).
     """
     match _line_size(buffer, offset)
     | let header_size: USize =>
@@ -111,6 +125,7 @@ primitive _RespParser
     """
     Determine size of an array at offset.
     Format: *<count>\r\n<element>...<element>  or  *-1\r\n for null.
+    Also used for RESP3 set (~) and push (>).
     """
     match _line_size(buffer, offset)
     | let header_size: USize =>
@@ -127,6 +142,44 @@ primitive _RespParser
         var total = header_size
         var i: I64 = 0
         while i < count do
+          match _complete_size(buffer, offset + total)
+          | let elem_size: USize => total = total + elem_size
+          | None => return None
+          | let m: RespMalformed => return m
+          end
+          i = i + 1
+        end
+        total
+      | let m: RespMalformed => m
+      end
+    | None => None
+    end
+
+  fun _map_size(buffer: Reader, offset: USize)
+    : (USize | None | RespMalformed)
+  =>
+    """
+    Determine size of a RESP3 map at offset.
+    Format: %<count>\r\n<key><value>...<key><value>  or  %-1\r\n for null.
+    Count is the number of key-value pairs; total elements = count * 2.
+    """
+    match _line_size(buffer, offset)
+    | let header_size: USize =>
+      match _read_line_as_i64(
+        buffer, offset + 1, (offset + header_size) - 2)
+      | let count: I64 =>
+        if count == -1 then
+          return header_size
+        end
+        if count < 0 then
+          return RespMalformed(
+            "negative map count: " + count.string())
+        end
+        let num_elements = try count.mul_partial(2)?
+        else return RespMalformed("map count overflow") end
+        var total = header_size
+        var i: I64 = 0
+        while i < num_elements do
           match _complete_size(buffer, offset + total)
           | let elem_size: USize => total = total + elem_size
           | None => return None
@@ -171,10 +224,10 @@ primitive _RespParser
       if (b < '0') or (b > '9') then
         return RespMalformed("non-digit byte in integer value")
       end
-      result = try 
+      result = try
         result.mul_partial(10)?.add_partial((b - '0').i64())?
-      else 
-        return RespMalformed("integer value out of range") 
+      else
+        return RespMalformed("integer value out of range")
       end
       i = i + 1
     end
@@ -227,6 +280,98 @@ primitive _RespParser
         end
         RespArray(consume arr)
       end
+    // RESP3 types
+    | '_' =>
+      buffer.line()?
+      RespNull
+    | '#' =>
+      let line = buffer.line()?
+      if line.size() != 1 then error end
+      let ch = line(0)?
+      if (ch != 't') and (ch != 'f') then error end
+      RespBoolean(ch == 't')
+    | ',' =>
+      let line = buffer.line()?
+      RespDouble((consume line).f64()?)
+    | '(' =>
+      let line = buffer.line()?
+      RespBigNumber(consume line)
+    | '!' =>
+      let line = buffer.line()?
+      let len = (consume line).i64()?
+      if len == -1 then error end
+      let data = buffer.block(len.usize())?
+      buffer.skip(2)?
+      RespBulkError(consume data)
+    | '=' =>
+      let line = buffer.line()?
+      let len = (consume line).i64()?
+      if len == -1 then error end
+      let data: Array[U8] val = recover val buffer.block(len.usize())? end
+      buffer.skip(2)?
+      if data.size() < 4 then error end
+      if data(3)? != ':' then error end
+      let enc_arr: Array[U8] val = recover val
+        let enc = Array[U8](3)
+        enc.push(data(0)?)
+        enc.push(data(1)?)
+        enc.push(data(2)?)
+        enc
+      end
+      let encoding = String.from_array(enc_arr)
+      let value: Array[U8] val = if data.size() > 4 then
+        data.trim(4)
+      else
+        recover val Array[U8] end
+      end
+      RespVerbatimString(encoding, value)
+    | '%' =>
+      let line = buffer.line()?
+      let count = (consume line).i64()?
+      if count == -1 then
+        RespNull
+      else
+        let pairs: Array[(RespValue, RespValue)] iso = recover iso
+          Array[(RespValue, RespValue)](count.usize())
+        end
+        var i: I64 = 0
+        while i < count do
+          let key = _parse(buffer)?
+          let value = _parse(buffer)?
+          pairs.push((key, value))
+          i = i + 1
+        end
+        RespMap(consume pairs)
+      end
+    | '~' =>
+      let line = buffer.line()?
+      let count = (consume line).i64()?
+      if count == -1 then
+        RespNull
+      else
+        let arr: Array[RespValue] iso = recover iso
+          Array[RespValue](count.usize())
+        end
+        var i: I64 = 0
+        while i < count do
+          arr.push(_parse(buffer)?)
+          i = i + 1
+        end
+        RespSet(consume arr)
+      end
+    | '>' =>
+      let line = buffer.line()?
+      let count = (consume line).i64()?
+      if count == -1 then error end
+      let arr: Array[RespValue] iso = recover iso
+        Array[RespValue](count.usize())
+      end
+      var i: I64 = 0
+      while i < count do
+        arr.push(_parse(buffer)?)
+        i = i + 1
+      end
+      RespPush(consume arr)
     else
       error
     end

--- a/redis/_response_handler.pony
+++ b/redis/_response_handler.pony
@@ -16,6 +16,7 @@ primitive _ResponseHandler
   fun apply(s: Session ref, readbuf: Reader) =>
     while true do
       match _RespParser(readbuf)
+      | let push: RespPush => s.state.on_push(s, push)
       | let v: RespValue => s.state.on_response(s, v)
       | None => return
       | let _: RespMalformed =>

--- a/redis/_test.pony
+++ b/redis/_test.pony
@@ -23,6 +23,15 @@ actor \nodoc\ Main is TestList
     test(_TestRespParserMultipleValues)
     test(_TestRespParserMalformedErrors)
     test(_TestRespParserIntegerOverflow)
+    test(_TestRespParserResp3Null)
+    test(_TestRespParserBoolean)
+    test(_TestRespParserDouble)
+    test(_TestRespParserBigNumber)
+    test(_TestRespParserBulkError)
+    test(_TestRespParserVerbatimString)
+    test(_TestRespParserMap)
+    test(_TestRespParserSet)
+    test(_TestRespParserPush)
 
     // Serializer property tests
     test(Property1UnitTest[Array[ByteSeq] val](
@@ -55,3 +64,10 @@ actor \nodoc\ Main is TestList
     test(_TestSessionSSLConnectionFailure)
     test(_TestSessionSSLConnectAndReady)
     test(_TestSessionSSLSetAndGet)
+    test(_TestSessionResp3ConnectAndReady)
+    test(_TestSessionResp3SetAndGet)
+    test(_TestSessionResp3FallbackToResp2)
+
+    // Command construction unit tests
+    test(_TestBuildHelloCommand)
+    test(_TestBuildAuthCommand)

--- a/redis/connect_info.pony
+++ b/redis/connect_info.pony
@@ -20,6 +20,18 @@ class val ConnectInfo
   Note: `SSLContext.set_authority()` is partial — the above must be in
   a partial context or wrapped in `try`.
 
+  To use RESP3 protocol features (maps, sets, booleans, doubles), set
+  `protocol' = Resp3`. The session sends HELLO 3 on connect and falls
+  back to RESP2 if the server doesn't support it:
+
+  ```pony
+  let info = ConnectInfo(auth, host where protocol' = Resp3)
+  ```
+
+  For Redis 6.0+ ACL authentication, provide a `username`. In RESP3 mode,
+  the username is included in the HELLO command. In RESP2 mode, it is
+  sent via `AUTH username password`.
+
   Redis AUTH sends the password in plaintext over TCP. Use `SSLRequired`
   when authenticating over untrusted networks.
   """
@@ -28,13 +40,19 @@ class val ConnectInfo
   let port: String
   let password: (String | None)
   let ssl_mode: SSLMode
+  let username: (String | None)
+  let protocol: ProtocolVersion
 
   new val create(auth': lori.TCPConnectAuth, host': String,
     port': String = "6379", password': (String | None) = None,
-    ssl_mode': SSLMode = SSLDisabled)
+    ssl_mode': SSLMode = SSLDisabled,
+    username': (String | None) = None,
+    protocol': ProtocolVersion = Resp2)
   =>
     auth = auth'
     host = host'
     port = port'
     password = password'
     ssl_mode = ssl_mode'
+    username = username'
+    protocol = protocol'

--- a/redis/protocol_version.pony
+++ b/redis/protocol_version.pony
@@ -1,0 +1,12 @@
+// Type alias can't have a docstring in Pony — see redis.pony for documentation.
+type ProtocolVersion is (Resp2 | Resp3)
+
+primitive Resp2
+  """RESP2 protocol (default). Compatible with all Redis versions."""
+
+primitive Resp3
+  """
+  RESP3 protocol. Requires Redis 6.0+. Enables richer response types
+  (maps, sets, booleans, doubles) and server-initiated push messages.
+  Falls back to RESP2 if the server does not support HELLO.
+  """

--- a/redis/resp_value.pony
+++ b/redis/resp_value.pony
@@ -1,10 +1,19 @@
+// Type alias can't have a docstring in Pony — see redis.pony for documentation.
 type RespValue is
   ( RespSimpleString
   | RespBulkString
   | RespInteger
   | RespArray
   | RespError
-  | RespNull )
+  | RespNull
+  | RespBoolean
+  | RespDouble
+  | RespBigNumber
+  | RespBulkError
+  | RespVerbatimString
+  | RespMap
+  | RespSet
+  | RespPush )
 
 class val RespSimpleString
   """
@@ -59,9 +68,98 @@ class val RespError
 
 primitive RespNull
   """
-  The RESP null value. Represents both null bulk strings (`$-1\r\n`) and
-  null arrays (`*-1\r\n`).
+  The RESP null value. In RESP2, represents null bulk strings (`$-1\r\n`)
+  and null arrays (`*-1\r\n`). In RESP3, also represents the explicit null
+  type (`_\r\n`) and null maps (`%-1\r\n`) and null sets (`~-1\r\n`).
   """
+
+class val RespBoolean
+  """
+  A RESP3 boolean value. Wire format: `#t\r\n` (true) or `#f\r\n` (false).
+  """
+  let value: Bool
+
+  new val create(value': Bool) =>
+    value = value'
+
+class val RespDouble
+  """
+  A RESP3 double-precision floating-point value. Wire format:
+  `,<value>\r\n`. Supports standard decimal notation, scientific notation,
+  and the special values `inf`, `-inf`, and `nan`.
+  """
+  let value: F64
+
+  new val create(value': F64) =>
+    value = value'
+
+class val RespBigNumber
+  """
+  A RESP3 arbitrary-precision integer. Wire format: `(<digits>\r\n`.
+  Stored as a string because the value may exceed the range of any
+  fixed-width integer type.
+  """
+  let value: String
+
+  new val create(value': String) =>
+    value = value'
+
+class val RespBulkError
+  """
+  A RESP3 bulk error. Like `RespError` but binary-safe — the message
+  can contain any bytes. Wire format: `!<len>\r\n<message>\r\n`.
+  """
+  let message: Array[U8] val
+
+  new val create(message': Array[U8] val) =>
+    message = message'
+
+class val RespVerbatimString
+  """
+  A RESP3 verbatim string. Carries a 3-character encoding hint (e.g.,
+  `"txt"` for plain text, `"mkd"` for Markdown) followed by the data.
+  Wire format: `=<len>\r\n<enc>:<data>\r\n` where `<enc>` is exactly
+  3 characters and `<len>` includes the encoding prefix and colon.
+  """
+  let encoding: String
+  let value: Array[U8] val
+
+  new val create(encoding': String, value': Array[U8] val) =>
+    encoding = encoding'
+    value = value'
+
+class val RespMap
+  """
+  A RESP3 map (dictionary). An ordered sequence of key-value pairs where
+  both keys and values are arbitrary RESP values. Wire format:
+  `%<count>\r\n<key><value>...` where `<count>` is the number of pairs.
+  """
+  let pairs: Array[(RespValue, RespValue)] val
+
+  new val create(pairs': Array[(RespValue, RespValue)] val) =>
+    pairs = pairs'
+
+class val RespSet
+  """
+  A RESP3 set. An unordered collection of RESP values. Wire format:
+  `~<count>\r\n<element>...`.
+  """
+  let values: Array[RespValue] val
+
+  new val create(values': Array[RespValue] val) =>
+    values = values'
+
+class val RespPush
+  """
+  A RESP3 push message. Server-initiated out-of-band data, used for
+  pub/sub messages and other server notifications. Wire format:
+  `><count>\r\n<element>...`. The first element is typically a bulk
+  string identifying the message type (e.g., "message", "subscribe").
+  """
+  let values: Array[RespValue] val
+
+  new val create(values': Array[RespValue] val) =>
+    values = values'
 
 class val RespMalformed
   """

--- a/redis/session_status_notify.pony
+++ b/redis/session_status_notify.pony
@@ -22,9 +22,10 @@ interface tag SessionStatusNotify
   be redis_session_ready(session: Session) =>
     """
     Called when the session is ready to accept commands. Fires after
-    successful AUTH when a password is configured, or immediately after
-    TCP connect when no password is set. Also fires when the session
-    exits pub/sub subscribed mode (subscription count reaches 0).
+    successful HELLO negotiation (RESP3), successful AUTH (RESP2 with
+    password), or immediately after TCP connect (RESP2, no password).
+    Also fires when the session exits pub/sub subscribed mode
+    (subscription count reaches 0).
     """
     None
 


### PR DESCRIPTION
Implement RESP3 (Redis 6.0+) protocol negotiation and all RESP3 value types, completing Phase 6 of the implementation plan (Discussion #2).

**Protocol layer**: Extend the `RespValue` union with 8 new types (`RespBoolean`, `RespDouble`, `RespBigNumber`, `RespBulkError`, `RespVerbatimString`, `RespMap`, `RespSet`, `RespPush`). The parser handles all RESP3 type bytes in both the completeness check and destructive parse passes.

**Session layer**: New `_SessionNegotiating` state for HELLO 3 handshake with automatic RESP2 fallback when the server doesn't support RESP3. `on_push` added to the state interface for routing RESP3 push messages separately from regular responses. `ConnectInfo` gains `protocol` and `username` fields.

**Response handler**: Routes `RespPush` before the general `RespValue` match arm so push messages reach `on_push` rather than `on_response`.

Tests: 9 new parser example tests (one per RESP3 type), 2 new integration tests (`Resp3ConnectAndReady`, `Resp3SetAndGet`), generators and equality helpers updated for all new types. Existing property tests automatically cover RESP3 types via the updated generators.