### PR TITLE
Differentiate closure errors in session state machine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Package: `redis`
 - `SessionStatusNotify` (in `session_status_notify.pony`): Lifecycle callback interface. All callbacks have default no-op implementations. Callbacks: `redis_session_connected`, `redis_session_connection_failed`, `redis_session_ready`, `redis_session_authentication_failed`, `redis_session_closed`.
 - `ResultReceiver` (in `result_receiver.pony`): Command response callback interface. Callbacks: `redis_response`, `redis_command_failed`.
 - `SubscriptionNotify` (in `subscription_notify.pony`): Pub/sub callback interface. All callbacks have default no-op implementations. Callbacks: `redis_subscribed`, `redis_unsubscribed`, `redis_message`, `redis_psubscribed`, `redis_punsubscribed`, `redis_pmessage`.
-- `ClientError` (in `client_error.pony`): Client-side error trait with `SessionNotReady`, `SessionClosed`, and `SessionInSubscribedMode` primitives.
+- `ClientError` (in `client_error.pony`): Client-side error trait with `SessionNotReady`, `SessionClosed`, `SessionConnectionLost`, `SessionProtocolError`, and `SessionInSubscribedMode` primitives.
 - `_ResponseHandler` (in `_response_handler.pony`): Loops `_RespParser` over a `buffered.Reader`, routing `RespPush` to `on_push` and other `RespValue`s to `on_response`. Shuts down on `RespMalformed`.
 - `_BuildHelloCommand` / `_BuildAuthCommand` (primitives in `session.pony`): Build HELLO 3 and AUTH commands for protocol negotiation and authentication.
 - `_IllegalState` / `_Unreachable` (in `_mort.pony`): Primitives for detecting impossible states.

--- a/redis/result_receiver.pony
+++ b/redis/result_receiver.pony
@@ -14,7 +14,10 @@ interface tag ResultReceiver
   be redis_command_failed(session: Session,
     command: Array[ByteSeq] val, failure: ClientError)
     """
-    Called when a command could not be sent to the server. The command
-    and the client-side error are provided so the caller knows which
+    Called when a command failed due to a client-side error. This covers
+    both commands that could not be sent (e.g., session not ready or
+    closed) and in-flight commands whose responses will never arrive
+    (e.g., connection lost or protocol error). The original command and
+    the specific `ClientError` are provided so the caller knows which
     command failed and why.
     """


### PR DESCRIPTION
The session has three distinct closure paths (connection lost, user close, protocol error) but all used `SessionClosed` when draining pending commands, making it impossible to diagnose why `SSLSetAndGet` fails intermittently in CI. This adds two new `ClientError` primitives and parameterizes `_drain_pending` so the next failure reveals whether the SSL connection is being dropped or the parser is rejecting data.

- `SessionConnectionLost` — delivered when `on_closed` fires (connection dropped by peer/network)
- `SessionProtocolError` — delivered when `shutdown` fires (`RespMalformed` from parser)
- `SessionClosed` — unchanged for user-initiated `close()` and post-close command rejection

Also updates `ResultReceiver.redis_command_failed` docstring to cover in-flight command losses, and updates the `PipelineClose` test to accept `SessionConnectionLost` since `close()` and `on_closed()` race.