### PR TITLE
Add backpressure support

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,10 @@ Command pipelining. Sends 3 SET commands followed by 3 GET commands without wait
 
 Pub/sub messaging using two sessions. One session subscribes to `demo-channel`, the other publishes a message to it. Demonstrates the `SubscriptionNotify` interface (`redis_subscribed`, `redis_message`, `redis_unsubscribed`) and the two-session pattern required because a subscribed session cannot execute regular commands.
 
+## backpressure
+
+TCP backpressure handling. Sends 1000 SET commands in a burst to exercise backpressure, implements `redis_session_throttled` and `redis_session_unthrottled` to observe when the TCP send buffer fills and drains. Shows that commands sent during backpressure are buffered internally and flushed automatically — no application-side retry logic is needed.
+
 ## ssl
 
 SSL/TLS-encrypted connection. Same workflow as `basic` (connects and sends PING) but over TLS using `SSLRequired`. Demonstrates how to create an `SSLContext` with a CA certificate, wrap it in `SSLRequired`, and pass it to `ConnectInfo`. Requires a Redis server configured for TLS. Set `REDIS_HOST`, `REDIS_PORT`, and `REDIS_CA_PATH` environment variables to match your server.

--- a/examples/backpressure/main.pony
+++ b/examples/backpressure/main.pony
@@ -1,0 +1,74 @@
+use "cli"
+use lori = "lori"
+// in your code this `use` statement would be:
+// use "redis"
+use "../../redis"
+
+actor Main
+  new create(env: Env) =>
+    let info = ServerInfo(env.vars)
+    let auth = lori.TCPConnectAuth(env.root)
+    Client(auth, info, env.out)
+
+actor Client is (SessionStatusNotify & ResultReceiver)
+  let _session: Session
+  let _out: OutStream
+  let _total: USize = 1000
+  var _sent: USize = 0
+  var _received: USize = 0
+
+  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+    _out = out
+    _session = Session(
+      ConnectInfo(auth, info.host, info.port),
+      this)
+
+  be redis_session_ready(session: Session) =>
+    _out.print("Connected and ready. Sending " + _total.string()
+      + " SET commands...")
+    _send_burst(session)
+
+  be redis_session_throttled(session: Session) =>
+    _out.print("Throttled after " + _sent.string() + " sends — "
+      + "commands are being buffered.")
+
+  be redis_session_unthrottled(session: Session) =>
+    _out.print("Unthrottled — flushing buffered commands.")
+
+  be redis_session_connection_failed(session: Session) =>
+    _out.print("Failed to connect.")
+
+  be redis_response(session: Session, response: RespValue) =>
+    _received = _received + 1
+    match RespConvert.as_error(response)
+    | let msg: String =>
+      _out.print("Error on response " + _received.string() + ": " + msg)
+    end
+    if _received == _total then
+      _out.print("All " + _total.string() + " responses received.")
+      _session.close()
+    end
+
+  be redis_command_failed(session: Session,
+    command: Array[ByteSeq] val, failure: ClientError)
+  =>
+    _out.print("Command failed: " + failure.message())
+    _session.close()
+
+  fun ref _send_burst(session: Session) =>
+    while _sent < _total do
+      let key: String val = "bp:" + _sent.string()
+      session.execute(RedisString.set(key, "value"), this)
+      _sent = _sent + 1
+    end
+
+class val ServerInfo
+  let host: String
+  let port: String
+
+  new val create(vars: (Array[String] val | None)) =>
+    let e = EnvVars(vars)
+    host = try e("REDIS_HOST")? else
+      ifdef linux then "127.0.0.2" else "localhost" end
+    end
+    port = try e("REDIS_PORT")? else "6379" end

--- a/redis/session_status_notify.pony
+++ b/redis/session_status_notify.pony
@@ -38,6 +38,23 @@ interface tag SessionStatusNotify
     """
     None
 
+  be redis_session_throttled(session: Session) =>
+    """
+    Called when the session starts experiencing TCP backpressure. Commands
+    sent via `execute()` are buffered internally and will be flushed
+    automatically when backpressure is released. No action is required
+    from the application unless it wants to reduce its sending rate.
+    """
+    None
+
+  be redis_session_unthrottled(session: Session) =>
+    """
+    Called when TCP backpressure is released. Buffered commands are being
+    flushed to the server. The application can resume sending at its
+    normal rate.
+    """
+    None
+
   be redis_session_closed(session: Session) =>
     """
     Called when the session has closed, whether by user request, server


### PR DESCRIPTION
When lori's send() encounters a full OS socket buffer, the session now buffers commands internally and flushes them automatically when the connection becomes writeable. This prevents silent data loss from ignored send() return values during backpressure.

The throttle state lives in the state machine classes (`_SessionReady` and `_SessionSubscribed`), not on the Session actor, following the existing pattern. A deferred `_flush_backpressure` behavior avoids calling send() from within lori's pending writes processing. Between the unthrottle callback and the flush behavior, `_throttled` remains true so intervening `execute()` calls continue to buffer, preserving FIFO order.

New `SessionStatusNotify` callbacks (`redis_session_throttled`, `redis_session_unthrottled`) inform the application of backpressure state changes. No application action is required — buffering is transparent.

Closes #25