### PR TITLE
Fix send() return value checks in non-throttled code paths

### DIFF
--- a/.release-notes/fix-send-return-value.md
+++ b/.release-notes/fix-send-return-value.md
@@ -1,0 +1,5 @@
+## Fix send() return value checks in non-throttled code paths
+
+Previously, when `execute()`, `subscribe()`, `psubscribe()`, `unsubscribe()`, or `punsubscribe()` sent a command while the session was not throttled, the return value from the underlying TCP send was ignored. If the connection had been lost, the command would be queued in the pending list but never actually sent over the wire, causing all subsequent command responses to be delivered to the wrong receivers.
+
+Now, all non-throttled send paths check the result. If the connection is no longer writeable, the session enters throttled mode and buffers the command for retry. If the connection is lost, the session shuts down and delivers appropriate errors to all pending command receivers.

--- a/redis/client_error.pony
+++ b/redis/client_error.pony
@@ -26,9 +26,11 @@ primitive SessionClosed is ClientError
 
 primitive SessionConnectionLost is ClientError
   """
-  Error returned when the connection to the Redis server was lost
-  unexpectedly. In-flight commands that were awaiting responses receive
-  this error via `redis_command_failed`.
+  Error returned when a command could not be completed because the
+  connection to the Redis server was lost. This covers commands that
+  could not be sent (the connection was already lost when `execute()`
+  was called) and in-flight commands that were awaiting responses when
+  the connection dropped.
   """
   fun message(): String => "Connection to Redis server was lost"
 


### PR DESCRIPTION
The non-throttled send paths in `_SessionReady.execute()`, `_SessionReady.subscribe()`/`psubscribe()`, and all four `_SessionSubscribed` send sites discarded the `send()` return value. If `send()` returned `SendErrorNotConnected`, the command would sit in `_pending` but was never sent, causing response mismatch for all subsequent commands. The backpressure PR (#27) fixed this in `flush_send_buffer()` but left the direct send paths unchecked.

Each site now matches on the send result: `SendToken` proceeds normally, `SendErrorNotWriteable` enters throttled mode and buffers the command for retry, and `SendErrorNotConnected` errors the triggering command (in `execute()`) and shuts down the session.

Closes #22