### PR TITLE
Fix shutdown() to propagate caller-specified error reason

### DIFF
--- a/redis/_response_handler.pony
+++ b/redis/_response_handler.pony
@@ -20,7 +20,7 @@ primitive _ResponseHandler
       | let v: RespValue => s.state.on_response(s, v)
       | None => return
       | let _: RespMalformed =>
-        s.state.shutdown(s)
+        s.state.shutdown(s, SessionProtocolError)
         return
       end
     end


### PR DESCRIPTION
shutdown() in _SessionReady and _SessionSubscribed hardcoded SessionProtocolError when draining pending commands and the send buffer. When shutdown was triggered by SendErrorNotConnected, pending commands incorrectly received SessionProtocolError instead of SessionConnectionLost.

Adds a `reason: ClientError` parameter to `shutdown()` on the `_SessionState` interface and all implementors. Each call site passes the appropriate error: `SessionProtocolError` for protocol violations, `SessionConnectionLost` for connection drops.

Closes #29