### PR TITLE
Fix send() return value checks in negotiation code paths

### DIFF
--- a/.release-notes/fix-negotiation-send-checks.md
+++ b/.release-notes/fix-negotiation-send-checks.md
@@ -1,5 +1,0 @@
-## Fix send() return value checks in negotiation code paths
-
-Previously, when the session sent HELLO (for RESP3 negotiation) or AUTH (for password authentication) immediately after TCP connection, the return value from the underlying TCP send was not checked. If the send failed, the session would hang indefinitely in a negotiating or authenticating state, waiting for a server response to a command that was never sent.
-
-Now, all negotiation send paths check the result. If the send fails, the session shuts down cleanly and fires `redis_session_closed`.


### PR DESCRIPTION
The HELLO and AUTH sends during connection negotiation didn't check the send() return value. If send() returned an error, the negotiation command was silently lost and the session would hang forever waiting for a response that would never arrive.

Each site is reordered so send() happens before the state transition. Only transition on successful send. On failure, shut down the session cleanly.

Closes #30