### PR TITLE
Update lori dependency from 0.12.0 to 0.13.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ make stop-redis
 
 ## Dependencies
 
-- `ponylang/lori` (0.12.0) — TCP networking (transitively depends on `ponylang/ssl`, hence the `ssl=` build flag)
+- `ponylang/lori` (0.13.0) — TCP networking (transitively depends on `ponylang/ssl`, hence the `ssl=` build flag)
 
 ## Architecture
 

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.12.0"
+      "version": "0.13.0"
     }
   ]
 }


### PR DESCRIPTION
Picks up a fix for a crash when dispose() arrives before connection initialization completes (a race between self-to-self and external messages with no causal ordering guarantee).