### PR TITLE
Update lori to 0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This library is under active development. The API is not yet stable.
 
 ## Installation
 
+* Requires ponyc 0.63.1 or later
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/redis.git --version 0.0.0`
 * `corral fetch` to fetch your dependencies

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.13.1"
+      "version": "0.14.0"
     }
   ]
 }

--- a/redis/connection_failure_reason.pony
+++ b/redis/connection_failure_reason.pony
@@ -18,8 +18,15 @@ primitive ConnectionFailedTimeout
   The connection attempt timed out before completing.
   """
 
+primitive ConnectionFailedTimerError
+  """
+  The connection was aborted because the connect timer's ASIO event
+  subscription failed.
+  """
+
 type ConnectionFailureReason is
   ( ConnectionFailedDNS
   | ConnectionFailedTCP
   | ConnectionFailedSSL
-  | ConnectionFailedTimeout )
+  | ConnectionFailedTimeout
+  | ConnectionFailedTimerError )

--- a/redis/session.pony
+++ b/redis/session.pony
@@ -122,6 +122,7 @@ actor Session is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
     | let _: lori.ConnectionFailedTCP => ConnectionFailedTCP
     | let _: lori.ConnectionFailedSSL => ConnectionFailedSSL
     | let _: lori.ConnectionFailedTimeout => ConnectionFailedTimeout
+    | let _: lori.ConnectionFailedTimerError => ConnectionFailedTimerError
     end
     state.on_failure(this, r)
 


### PR DESCRIPTION
Picks up ASIO_ERROR handling for timer subscription failures, adds ConnectionFailedTimerError to ConnectionFailureReason, and requires ponyc 0.63.1 or later.