### PR TITLE
Update lori to 0.14.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ make stop-redis
 
 ## Dependencies
 
-- `ponylang/lori` (0.13.1) — TCP networking (transitively depends on `ponylang/ssl`, hence the `ssl=` build flag)
+- `ponylang/lori` (0.14.1) — TCP networking (transitively depends on `ponylang/ssl`, hence the `ssl=` build flag)
 
 ## Architecture
 

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.14.0"
+      "version": "0.14.1"
     }
   ]
 }

--- a/redis/session.pony
+++ b/redis/session.pony
@@ -138,6 +138,12 @@ actor Session is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
   fun ref _on_unthrottled() =>
     state.on_unthrottled(this)
 
+  fun ref _on_idle_timer_failure() =>
+    _Unreachable()
+
+  fun ref _on_timer_failure() =>
+    _Unreachable()
+
   be _flush_backpressure() =>
     """
     Deferred flush of the backpressure send buffer. Triggered by


### PR DESCRIPTION
0.14.1 adds `_on_idle_timer_failure` and `_on_timer_failure` lifecycle callbacks for timer ASIO subscription failures. We don't use lori's idle timeout or user timer APIs in this project, so these callbacks should never fire — `_Unreachable()` surfaces it loudly if they ever do.