### PR TITLE
Require ponyc 0.64.0 or later

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -21,7 +21,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/library-documentation-action-v2:release
+      image: ghcr.io/ponylang/library-documentation-action-v2:nightly
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,7 @@ jobs:
     name: Test against recent ponyc release
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
     services:
       redis:
         image: redis:7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
     needs:
       - pre-artefact-creation
     container:
-      image: ghcr.io/ponylang/library-documentation-action-v2:release
+      image: ghcr.io/ponylang/library-documentation-action-v2:nightly
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ make stop-redis
 
 ## Dependencies
 
-- `ponylang/lori` (0.14.1) — TCP networking (transitively depends on `ponylang/ssl`, hence the `ssl=` build flag)
+- `ponylang/lori` (0.15.0) — TCP networking (transitively depends on `ponylang/ssl`, hence the `ssl=` build flag)
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This library is under active development. The API is not yet stable.
 
 ## Installation
 
-* Requires ponyc 0.63.1 or later
+* Requires ponyc 0.64.0 or later
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/redis.git --version 0.0.0`
 * `corral fetch` to fetch your dependencies

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.14.1"
+      "version": "0.15.0"
     }
   ]
 }


### PR DESCRIPTION
Updates redis to use lori 0.15.0, which requires ponyc 0.64.0 or later. Switches CI workflows that pull `shared-docker-ci-standard-builder-with-libressl-4.2.1` and `library-documentation-action-v2` from the `:release` channel to `:nightly` so they can build against the soon-to-be-released ponyc 0.64.0.

No release note file added — redis is still at VERSION 0.0.0.

Will need a follow-up to switch back to `:release` once ponyc 0.64.0 ships (tracked in ponylang/ponyc#5298).