### PR TITLE
Switch CI from ponyc nightly back to release

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -21,7 +21,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/library-documentation-action-v2:nightly
+      image: ghcr.io/ponylang/library-documentation-action-v2:release
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,7 @@ jobs:
     name: Test against recent ponyc release
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
     services:
       redis:
         image: redis:7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
     needs:
       - pre-artefact-creation
     container:
-      image: ghcr.io/ponylang/library-documentation-action-v2:nightly
+      image: ghcr.io/ponylang/library-documentation-action-v2:release
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2


### PR DESCRIPTION
Now that 0.64.0 is released, switch the CI workflows back from nightly ponyc to release ponyc.