### PR TITLE
Update lori to 0.15.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ make stop-redis
 
 ## Dependencies
 
-- `ponylang/lori` (0.15.0) — TCP networking (transitively depends on `ponylang/ssl`, hence the `ssl=` build flag)
+- `ponylang/lori` (0.15.1) — TCP networking (transitively depends on `ponylang/ssl`, hence the `ssl=` build flag)
 
 ## Architecture
 

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.15.0"
+      "version": "0.15.1"
     }
   ]
 }


### PR DESCRIPTION
Updates the lori dependency to 0.15.1. redis is unreleased, so no release note.