### PR TITLE
Update lori to 0.16.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ make stop-redis
 
 ## Dependencies
 
-- `ponylang/lori` (0.15.1) — TCP networking (transitively depends on `ponylang/ssl`, hence the `ssl=` build flag)
+- `ponylang/lori` (0.16.0) — TCP networking (transitively depends on `ponylang/ssl`, hence the `ssl=` build flag)
 
 ## Architecture
 

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.15.1"
+      "version": "0.16.0"
     }
   ]
 }


### PR DESCRIPTION
Updates lori to 0.16.0, which moves Windows networking from IOCP to readiness notifications. No release note: redis is unreleased (VERSION 0.0.0).