### PR TITLE
Cut AGENTS.md to what the code cannot tell an agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,6 @@
-# Redis Client for Pony
+# redis
+
+A Redis client for Pony. Speaks RESP2 and RESP3, with pub/sub and pipelined commands.
 
 <!-- contributor-only -->
 ## Contributing with an AI assistant
@@ -22,97 +24,32 @@ When you start working on this project, load the `pony-skills` skill — it tell
 Read [CONTRIBUTING.md](CONTRIBUTING.md).
 <!-- /contributor-only -->
 
-## Building
+## Building and testing
 
 ```
-make                    # build and run all tests (requires Redis running)
-make unit-tests         # run unit tests only (no Redis needed)
-make test-one t=TestName ssl=3.0.x  # run a single test by name
-make integration-tests  # run integration tests only (requires Redis)
-make examples           # build example programs
-make start-redis        # start plaintext, SSL, and RESP2-only Redis in Docker
-make stop-redis         # stop and remove all Redis containers
-make clean              # clean build artifacts
+make ssl=3.0.x                       # build + run all tests (needs Redis running)
+make unit-tests ssl=3.0.x            # unit tests only (no Redis needed)
+make test-one t=TestName ssl=3.0.x   # run a single test by name
+make integration-tests ssl=3.0.x     # integration tests only (needs Redis)
+make examples ssl=3.0.x              # build examples
+make start-redis                     # start plaintext, SSL, and RESP2-only Redis in Docker
+make stop-redis                      # stop and remove them
+make clean                           # clean build artifacts
 ```
 
-All build targets require `ssl=<version>` (e.g., `ssl=3.0.x` for OpenSSL 3.x, `ssl=libressl` for LibreSSL). This is needed because lori depends on the ssl package. Add `config=debug` for debug builds.
+`ssl=` is required on build targets (lori pulls in `ssl`): for example `ssl=3.0.x` for OpenSSL 3.x, `ssl=libressl` for LibreSSL. Add `config=debug` for a debug build.
 
-### Running Tests Locally
-
-```
-make start-redis
-make test config=debug ssl=3.0.x
-make stop-redis
-```
-
-## Dependencies
-
-- `ponylang/lori` (0.16.1) — TCP networking (transitively depends on `ponylang/ssl`, hence the `ssl=` build flag)
+Run the integration tests locally with `make start-redis`, then `make test ssl=3.0.x`, then `make stop-redis`. They read `REDIS_*` environment variables (see `_RedisTestConfiguration`), which default to `127.0.0.2` on Linux rather than the usual loopback, dodging the WSL2 mirrored-networking hang.
 
 ## Architecture
 
-Package: `redis`
-
-### Protocol Layer
-
-- `RespValue` (union type in `resp_value.pony`): Core type for RESP2/RESP3 wire format values. Union of `RespSimpleString`, `RespBulkString`, `RespInteger`, `RespArray`, `RespError`, `RespNull`, `RespBoolean`, `RespDouble`, `RespBigNumber`, `RespBulkError`, `RespVerbatimString`, `RespMap`, `RespSet`, `RespPush`.
-- `RespMalformed` (in `resp_value.pony`): Parser error type indicating invalid RESP data. Not part of `RespValue` — represents a protocol violation, not a valid value.
-- `_RespParser` (in `_resp_parser.pony`): Two-pass parser — peek-based completeness check, then destructive parse. Returns `(RespValue | None | RespMalformed)` from a `buffered.Reader`. Supports all RESP2 and RESP3 type bytes.
-- `_RespSerializer` (in `_resp_serializer.pony`): Serializes commands (`Array[ByteSeq] val`) to RESP2 wire format.
-- `ProtocolVersion` (type alias in `protocol_version.pony`): `(Resp2 | Resp3)`. Controls which protocol the session negotiates on connect.
-
-### Session Layer
-
-- `Session` (actor in `session.pony`): Main entry point. Manages connection lifecycle and pub/sub via a state machine. Implements `lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver`. All state machine classes (`_SessionUnopened`, `_SessionNegotiating`, `_SessionConnected`, `_SessionReady`, `_SessionSubscribed`, `_SessionClosed`) are in `session.pony`, following the postgres pattern.
-- `ConnectInfo` (in `connect_info.pony`): Connection configuration (host, port, optional password, SSL mode, optional username, protocol version, send buffer limit).
-- `SessionStatusNotify` (in `session_status_notify.pony`): Lifecycle callback interface. All callbacks have default no-op implementations. Callbacks: `redis_session_connected`, `redis_session_connection_failed(session, reason)`, `redis_session_ready`, `redis_session_authentication_failed`, `redis_session_throttled`, `redis_session_unthrottled`, `redis_session_closed`.
-- `ResultReceiver` (in `result_receiver.pony`): Command response callback interface. Callbacks: `redis_response`, `redis_command_failed`.
-- `SubscriptionNotify` (in `subscription_notify.pony`): Pub/sub callback interface. All callbacks have default no-op implementations. Callbacks: `redis_subscribed`, `redis_unsubscribed`, `redis_message`, `redis_psubscribed`, `redis_punsubscribed`, `redis_pmessage`.
-- `ClientError` (in `client_error.pony`): Client-side error trait with `SessionNotReady`, `SessionClosed`, `SessionConnectionLost`, `SessionProtocolError`, `SessionInSubscribedMode`, and `SessionBackpressureOverflow` primitives.
-- `_ResponseHandler` (in `_response_handler.pony`): Loops `_RespParser` over a `buffered.Reader`, routing `RespPush` to `on_push` and other `RespValue`s to `on_response`. Shuts down on `RespMalformed`.
-- `_BuildHelloCommand` / `_BuildAuthCommand` (primitives in `session.pony`): Build HELLO 3 and AUTH commands for protocol negotiation and authentication.
-- `_BufferedSend` (class val in `session.pony`): Serialized command buffered during backpressure. Holds wire-format bytes and an optional `_QueuedCommand` for response matching.
-- `ConnectionFailureReason` (type alias in `connection_failure_reason.pony`): `(ConnectionFailedDNS | ConnectionFailedTCP | ConnectionFailedSSL | ConnectionFailedTimeout)`. Passed to `redis_session_connection_failed` to identify the failure stage.
-- `_IllegalState` / `_Unreachable` (in `_mort.pony`): Primitives for detecting impossible states.
-
-### Command Builders
-
-Six public primitives for constructing common Redis commands as `Array[ByteSeq] val`. Each method is a pure function.
-
-- `RedisServer` (in `redis_server.pony`): PING, ECHO, DBSIZE, FLUSHDB.
-- `RedisString` (in `redis_string.pony`): GET, SET (with NX/EX variants), INCR, DECR, INCRBY, DECRBY, MGET, MSET.
-- `RedisKey` (in `redis_key.pony`): DEL, EXISTS, EXPIRE, TTL, PERSIST, KEYS, RENAME, TYPE (as `type_of`).
-- `RedisHash` (in `redis_hash.pony`): HGET, HSET, HDEL, HGETALL, HEXISTS.
-- `RedisList` (in `redis_list.pony`): LPUSH, RPUSH, LPOP, RPOP, LLEN, LRANGE.
-- `RedisSet` (in `redis_set.pony`): SADD, SREM, SMEMBERS, SISMEMBER, SCARD.
-
-Fixed-argument commands use `recover val [as ByteSeq: ...] end`. Variadic commands use `recover val` with `Array.push` loops.
-
-### Response Extraction
-
-- `RespConvert` (primitive in `resp_convert.pony`): Total functions for extracting typed values from `RespValue`. Each extractor returns `(T | RespNull | None)` except `as_error` → `(String | None)` and `is_ok` → `Bool`. Methods: `as_string`, `as_bytes`, `as_integer`, `as_bool`, `as_array`, `as_double`, `as_big_number`, `as_map`, `as_set`, `as_error`, `is_ok`.
-
-### SSL/TLS
-
-- `SSLMode` (type alias in `ssl_mode.pony`): `(SSLDisabled | SSLRequired)`. Controls whether the session uses plaintext TCP or SSL/TLS.
-- `SSLDisabled` (primitive in `ssl_mode.pony`): Plaintext TCP connection (default).
-- `SSLRequired` (class val in `ssl_mode.pony`): Wraps an `SSLContext val` for direct TLS connections. Redis uses direct TLS (typically port 6380) rather than STARTTLS.
-- The `ssl/net` package is a transitive dependency via lori (no `corral.json` change needed). Adding `use "ssl/net"` in source files is sufficient.
-
-### Trait Composition
-
-- `_ClosedState`: Mixin for the terminal state — rejects or no-ops all operations.
-- `_ConnectedState`: Mixin for states with a readbuf — handles `on_received` and `_ResponseHandler` dispatch.
-- `_NotReadyForCommands`: Mixin that rejects `execute()` with `SessionNotReady`.
-- `_NotSubscribed`: Mixin that no-ops `subscribe`, `unsubscribe`, `psubscribe`, `punsubscribe` for states where pub/sub is not applicable. Also provides a no-op `on_push` for states that don't handle push messages (only trait that provides `on_push`, to avoid diamond inheritance in `_SessionClosed`).
-- `_NotThrottleable`: Mixin that no-ops `on_throttled`, `on_unthrottled`, and `flush_send_buffer` for states that don't handle backpressure (pre-ready states, closed state).
-
-### State Machine
+The `Session` actor is the entry point. It tracks connection and pub/sub lifecycle with explicit state classes, all in `session.pony`.
 
 ```
 _SessionUnopened ──on_connected──► _SessionNegotiating (if Resp3)
                  ──on_connected──► _SessionConnected (if Resp2 + password)
                  ──on_connected──► _SessionReady (if Resp2, no password)
+                 ──on_failure──► _SessionClosed
 
 _SessionNegotiating ──HELLO map──► _SessionReady
                     ──HELLO error──► _SessionConnected (if password, send AUTH)
@@ -128,37 +65,13 @@ _SessionSubscribed ──unsub count 0──► _SessionReady
                    ──close/error──► _SessionClosed
 ```
 
-Commands are pipelined in `_SessionReady`: each `execute()` call sends the command immediately over the wire without waiting for prior responses. Responses are matched to receivers in FIFO order. When TCP backpressure is active, commands are serialized and buffered in a `_send_buffer` instead of being sent immediately. The buffer is bounded by `_send_buffer_limit` (from `ConnectInfo.send_buffer_limit`, default 1024) — commands that exceed the limit are rejected with `SessionBackpressureOverflow`. The buffer is flushed via a deferred `_flush_backpressure` behavior when backpressure is released. Both `_SessionReady` and `_SessionSubscribed` carry `_throttled`, `_send_buffer`, and `_send_buffer_limit` state, which is passed across transitions between the two states. Internal commands (SUBSCRIBE, UNSUBSCRIBE, etc.) are exempt from the limit.
+## Testing
 
-In `_SessionSubscribed`, any pipelined commands that were in-flight when SUBSCRIBE was sent are drained first (Redis guarantees in-order response delivery), then incoming responses are routed as pub/sub messages. In RESP3 mode, pub/sub messages arrive as `RespPush` via `on_push`; in RESP2 mode they arrive as `RespArray` via `on_response`.
+- **Never connect with SSL to a plaintext Redis server, even in a test.** The TLS ClientHello carries no `\r\n`, so Redis's RESP parser buffers it forever waiting for a line terminator while the SSL client waits for a ServerHello — both block indefinitely. To exercise the SSL constructor path, connect to a non-listening port instead; connection-refused is fast and deterministic.
+- Backpressure tests use a fake server built on lori's listener/connection APIs, because real Redis fill rates vary by environment. The fake listener must track the connections it spawns and dispose them in `_on_closed()`, or the test hangs.
+- Integration tests are named `integration/…` and set `exclusion_group() => "integration"`; they need a running Redis.
 
-## Test Infrastructure
+## Conventions
 
-- Unit tests: `--exclude=integration/` — no external dependencies
-- Integration tests: `--only=integration/` — require a running Redis server
-- Test names prefixed with `integration/` for filtering
-- `_RedisTestConfiguration` reads environment variables for plaintext, SSL, and RESP2-only Redis:
-  - `REDIS_HOST` / `REDIS_PORT` — plaintext (defaults to `127.0.0.2`/`6379` on Linux)
-  - `REDIS_SSL_HOST` / `REDIS_SSL_PORT` — TLS (defaults to same host/`6380`)
-  - `REDIS_RESP2_HOST` / `REDIS_RESP2_PORT` — RESP2-only Redis 5 (defaults to same host/`6381`)
-
-### Fake Server Tests
-
-Some behaviors (e.g., TCP backpressure) can't be tested reliably against a real Redis server because they depend on OS buffer fill rates that vary across environments. These tests use a fake server built with lori's `TCPListenerActor`/`TCPConnectionActor` APIs. The server connection actor controls behavior (e.g., muting to stop reading, causing TCP buffers to fill deterministically). Since no Redis protocol exchange is needed, the client connects with RESP2 and no password, which transitions directly to `_SessionReady` on TCP connect. These are unit tests (no `exclusion_group`, no Redis needed). The listener must track spawned server connections and dispose them in `_on_closed()` to avoid test hangs.
-
-### SSL-to-Plaintext Deadlock
-
-Do not write tests that connect with SSL to a plaintext Redis server. The TLS ClientHello is binary data with no `\r\n`, so Redis's RESP parser buffers it waiting for a line terminator. Meanwhile the SSL client waits for a ServerHello. Neither side sends more data — both block indefinitely. To test the SSL constructor path, connect to a non-listening port instead (TCP connection refused is fast and deterministic).
-
-### CI
-
-Both `pr.yml` and `breakage-against-ponyc-latest.yml` use the `shared-docker-ci-standard-builder-with-libressl-4.2.1` image (for ssl support) and three Redis service containers: `redis` (plaintext, Redis 7), `redis-ssl` (TLS via `ghcr.io/ponylang/redis-ci-redis-ssl:latest`), and `redis-resp2` (Redis 5, RESP2-only for HELLO fallback testing). Integration tests receive `REDIS_HOST=redis`, `REDIS_PORT=6379`, `REDIS_SSL_HOST=redis-ssl`, `REDIS_SSL_PORT=6379`, `REDIS_RESP2_HOST=redis-resp2`, and `REDIS_RESP2_PORT=6379`. All make targets pass `ssl=libressl`.
-
-The `redis-ssl` CI image is built via `build-ci-image.yml` (manually triggered `workflow_dispatch`). Source: `.ci-dockerfiles/redis-ssl/Dockerfile`. Build locally with `.ci-dockerfiles/redis-ssl/build-and-push.bash`.
-
-## File Layout
-
-- `redis/` — main package source
-- `examples/` — example programs
-- `assets/` — test certificates for SSL Redis container
-- `.ci-dockerfiles/` — Dockerfiles for CI service containers
+- Impossible states call `_IllegalState()` / `_Unreachable()` (`_mort.pony`).
+- `\nodoc\` on test classes.


### PR DESCRIPTION
AGENTS.md was 164 lines, most of it a second copy of the code: the RESP protocol types, the session and command-builder and trait enumerations, the response-extraction and codec catalogues, and a source-tree listing — each owned by its own file and the package docstring.

Applying the pony-agents-md principle — a line earns its place only if reading it here is cheaper and truer than learning it from the repo — this keeps the commands and container setup, the session-lifecycle diagram, and the two traps a cold agent would otherwise re-hit: the SSL-to-plaintext deadlock and the fake-server dispose-or-hang rule. 164 to ~55 lines.