### PR TITLE
Update lori to 0.17.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ make stop-redis                      # stop and remove them
 make clean                           # clean build artifacts
 ```
 
-`ssl=` is required on build targets (lori pulls in `ssl`): for example `ssl=3.0.x` for OpenSSL 3.x, `ssl=libressl` for LibreSSL. Add `config=debug` for a debug build.
+`ssl=` is required on build targets (lori pulls in `ssl`), set to your installed TLS library: `4.0.x`, `3.0.x`, `1.1.x`, or `libressl`. Add `config=debug` for a debug build.
 
 Run the integration tests locally with `make start-redis`, then `make test ssl=3.0.x`, then `make stop-redis`. They read `REDIS_*` environment variables (see `_RedisTestConfiguration`), which default to `127.0.0.2` on Linux rather than the usual loopback, dodging the WSL2 mirrored-networking hang.
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,9 @@ else
 endif
 
 ifeq (,$(filter $(MAKECMDGOALS),clean docs start-redis stop-redis TAGS))
-  ifeq ($(ssl), 3.0.x)
+  ifeq ($(ssl), 4.0.x)
+          SSL = -Dopenssl_4.0.x
+  else ifeq ($(ssl), 3.0.x)
           SSL = -Dopenssl_3.0.x
   else ifeq ($(ssl), 1.1.x)
           SSL = -Dopenssl_1.1.x

--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@ This library is under active development. The API is not yet stable.
 
 ## Installation
 
-* Requires ponyc 0.64.0 or later. On Windows, requires ponyc 0.66.0 or later.
+* Requires ponyc 0.67.0 or later.
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/redis.git --version 0.0.0`
 * `corral fetch` to fetch your dependencies
 * `use "redis"` to include this package
 * `corral run -- ponyc` to compile your application
+
+This library has a transitive dependency on [ponylang/ssl](https://github.com/ponylang/ssl). It requires a C SSL library to be installed. Please see the [ssl installation instructions](https://github.com/ponylang/ssl?tab=readme-ov-file#installation) for more information.
 
 ## API Documentation
 

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.16.1"
+      "version": "0.17.0"
     }
   ]
 }

--- a/redis/session.pony
+++ b/redis/session.pony
@@ -126,8 +126,9 @@ actor Session is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
     end
     state.on_failure(this, r)
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     state.on_received(this, consume data)
+    lori.KeepReading
 
   fun ref _on_closed() =>
     state.on_closed(this)


### PR DESCRIPTION
lori 0.17.0 removes `TCPConnection.yield_read()` and has `_on_received` return a `ReadAction` instead, so the return value now controls whether the read loop keeps reading. redis's `Session` never needs to pause the loop, so it returns `KeepReading`.

lori 0.17.0 requires ssl 3.0.0 and ponyc 0.67.0, so those move too. redis has never been released, so there is no CHANGELOG entry or release note to write.
